### PR TITLE
Use GTF files with featureCounts, don't always always compute the gen…

### DIFF
--- a/shared/rules/featureCounts.snakefile
+++ b/shared/rules/featureCounts.snakefile
@@ -4,7 +4,7 @@
 rule featureCounts:
     input:
         bam = mapping_prg+"/{sample}.bam",
-        saf = "Annotation/genes.filtered.saf",
+        anno = genes_gtf
     output:
         "featureCounts/{sample}.counts.txt"
     params:
@@ -19,7 +19,7 @@ rule featureCounts:
         "{params.paired_opt}{params.opts} "
         "-T {threads} "
         "-s {params.libtype} "
-        "-F SAF -a {input.saf} "
+        "-a {input.anno} "
         "-o {output} "
         "--tmpDir ${{TMPDIR}} "
         "{input.bam} &>> {log} "

--- a/shared/rules/featureCounts_allelic.snakefile
+++ b/shared/rules/featureCounts_allelic.snakefile
@@ -3,7 +3,7 @@
 
 rule featureCounts_allele:
     input:
-        saf = "Annotation/genes.filtered.saf",
+        anno = genes_gtf,
         bam = "allelic_bams/{sample}.allele_flagged.sorted.bam",
         allele1 = "allelic_bams/{sample}.genome1.sorted.bam",
         allele2 = "allelic_bams/{sample}.genome2.sorted.bam"
@@ -21,7 +21,7 @@ rule featureCounts_allele:
         " {params.paired_opt}{params.opts}"
         " -T {threads}"
         " -s {params.libtype}"
-        " -F SAF -a {input.saf}"
+        " -a {input.anno}"
         " -o {output}"
         " --tmpDir ${{TMPDIR}}"
         " {input.bam} {input.allele1} {input.allele2} &>> {log}"

--- a/workflows/RNA-seq/RNA-seq
+++ b/workflows/RNA-seq/RNA-seq
@@ -29,7 +29,7 @@ def parse_args(defaults={"verbose":None,"configfile":None,"max_jobs":None,"snake
                          "mode":None, "downsample":None, "trim":None,"trim_prg":None,"trim_options":None, "fastqc":None,
                          "library_type":None, "mapping_prg":None, "star_options":None, "hisat_options":None, "salmon_index_options":None,
                          "featurecounts_options":None, "filter_annotation":None, "sample_info":None,
-                         "bw_binsize":None, "genomic_contamination":None, "mapq":None}):
+                         "bw_binsize":None, "genomic_contamination":False, "mapq":None}):
     """
     Parse arguments from the command line.
     """

--- a/workflows/RNA-seq/Snakefile
+++ b/workflows/RNA-seq/Snakefile
@@ -87,7 +87,8 @@ if sample_info:
 include: os.path.join(maindir, "shared", "rules", "multiQC.snakefile")
 
 ##Genomic_contamination
-include: os.path.join(maindir, "shared", "rules", "GenomicContamination.snakefile")
+if genomic_contamination:
+    include: os.path.join(maindir, "shared", "rules", "GenomicContamination.snakefile")
 
 ### conditional/optional rules #################################################
 ################################################################################
@@ -203,6 +204,7 @@ def run_deeptools_qc():
 def run_GenomicContamination():
     if genomic_contamination:
        file_list = [expand("GenomicContamination/{sample}.featurecounts.txt", sample = samples)]
+       file_list.append("GenomicContamination/genomic_contamination_featurecount_report.tsv")
        return (file_list)
     else:
        return([])
@@ -239,7 +241,6 @@ rule all:
 
         "Annotation/genes.annotated.bed",
         "Annotation/genes.filtered.bed",
-        "Annotation/genes.filtered.saf",    # this file is used for featureCounts later on!
         run_mapping_free(),            # Salmon
         run_mapping(),                 # classical mapping + counting
 	run_allelesp_mapping(),        # allelic-mapping
@@ -247,7 +248,6 @@ rule all:
         run_deeptools_qc(),
         "Sambamba/flagstat_report_all.tsv",
         run_GenomicContamination(),
-        "GenomicContamination/genomic_contamination_featurecount_report.tsv",
         "multiQC/multiqc_report.html"
 
 


### PR DESCRIPTION
…omic contamination in the RNAseq pipeline

This fixes #90 and an additional bug wherein the genomic contamination stuff is always run, regardless whether one specifies `-GC` or not.