### PR TITLE
Star sorting bins

### DIFF
--- a/shared/rules/RNA_mapping.snakefile
+++ b/shared/rules/RNA_mapping.snakefile
@@ -128,6 +128,7 @@ elif mapping_prg.upper().find("STAR") >=0:
                 "--genomeDir {params.index} "
                 "--readFilesIn {input.r1} {input.r2} "
                 "--outFileNamePrefix {params.prefix} "
+                " --outBAMsortingBinsN 100"
                 "&& mv {params.prefix}Aligned.sortedByCoord.out.bam {output.bam} "
     else:
         rule STAR:
@@ -158,4 +159,5 @@ elif mapping_prg.upper().find("STAR") >=0:
                 "--genomeDir {params.index} "
                 "--readFilesIn {input} "
                 "--outFileNamePrefix {params.prefix} "
+                " --outBAMsortingBinsN 100"
                 "&& mv {params.prefix}Aligned.sortedByCoord.out.bam {output.bam} "

--- a/shared/rules/RNA_mapping_allelic.snakefile
+++ b/shared/rules/RNA_mapping_allelic.snakefile
@@ -46,6 +46,7 @@ if mapping_prg == "STAR":
                 " --alignIntronMin 1"
                 " --alignIntronMax 1000000"
                 " --alignMatesGapMax 1000000"
+                " --outBAMsortingBinsN 100"
                 " && mv {params.prefix}Aligned.sortedByCoord.out.bam {output} "
     else:
         rule STAR_allele:
@@ -89,6 +90,7 @@ if mapping_prg == "STAR":
                 " --alignIntronMin 1"
                 " --alignIntronMax 1000000"
                 " --alignMatesGapMax 1000000"
+                " --outBAMsortingBinsN 100"
                 " && mv {params.prefix}Aligned.sortedByCoord.out.bam {output}"
 else:
     print("Only STAR is implemented for Allele-specific mapping")


### PR DESCRIPTION
This will prevent large RNAseq datasets from failing when using dm6 and other smaller genomes.