### PR TITLE
R stats-related fixes

### DIFF
--- a/snakePipes/shared/rscripts/WGBSpipe.interval_stats.limma.R
+++ b/snakePipes/shared/rscripts/WGBSpipe.interval_stats.limma.R
@@ -108,7 +108,7 @@ if(nrow(bedtab.CC)==0) {message("None of the genomic intervals passed the filter
 #calculate and save row means
     CGI.limdat.CC$IntID<-rownames(CGI.limdat.CC)
     CGI.limdat.CC.L<-melt(CGI.limdat.CC,id.vars="IntID",value.name="Beta",variable.name="SampleID")
-    CGI.limdat.CC.L$Group<-sampleInfo$Group[match(CGI.limdat.CC.L$SampleID,sampleInfo$PlottingID)]
+    CGI.limdat.CC.L$Group<-sampleInfo$Group[match(CGI.limdat.CC.L$SampleID,sampleInfo$SampleID)]
     CGI.limdat.CC.Means<-data.table(summarize(group_by(CGI.limdat.CC.L,IntID,Group),Beta.Mean=mean(Beta)))
 
 
@@ -136,10 +136,10 @@ if(nrow(bedtab.CC)==0) {message("None of the genomic intervals passed the filter
     colnames(design)<-c("Intercept","Group")
     rownames(design)<-colnames(CGI.limdat.CC.logit)
     if("Control" %in% sampleInfo$Group){
-        gp<-factor(sampleInfo$Group[match(colnames(CGI.limdat.CC.logit),sampleInfo$PlottingID)])
+        gp<-factor(sampleInfo$Group[match(colnames(CGI.limdat.CC.logit),sampleInfo$SampleID)])
         gp<-relevel(gp,ref="Control")}
     if("WT" %in% sampleInfo$Group){
-        gp<-factor(sampleInfo$Group[match(colnames(CGI.limdat.CC.logit),sampleInfo$PlottingID)])
+        gp<-factor(sampleInfo$Group[match(colnames(CGI.limdat.CC.logit),sampleInfo$SampleID)])
         gp<-relevel(gp,ref="WT")}
     design$Group<-as.numeric(gp)
     design$Intercept<-1

--- a/snakePipes/shared/rscripts/WGBSpipe.metilene_stats.limma.R
+++ b/snakePipes/shared/rscripts/WGBSpipe.metilene_stats.limma.R
@@ -107,7 +107,7 @@ if (length(readLines(bedF))==0) {message("No DMRs found.")}else{
     #calculate and save row means
         CGI.limdat.CC$IntID<-rownames(CGI.limdat.CC)
         CGI.limdat.CC.L<-melt(CGI.limdat.CC,id.vars="IntID",value.name="Beta",variable.name="SampleID")
-        CGI.limdat.CC.L$Group<-sampleInfo$Group[match(CGI.limdat.CC.L$SampleID,sampleInfo$PlottingID)]
+        CGI.limdat.CC.L$Group<-sampleInfo$Group[match(CGI.limdat.CC.L$SampleID,sampleInfo$SampleID)]
         CGI.limdat.CC.Means<-data.table(summarize(group_by(CGI.limdat.CC.L,IntID,Group),Beta.Mean=mean(Beta)))
 
     if ("Control" %in% CGI.limdat.CC.Means$Group){
@@ -132,10 +132,10 @@ if (length(readLines(bedF))==0) {message("No DMRs found.")}else{
         colnames(design)<-c("Intercept","Group")
         rownames(design)<-colnames(CGI.limdat.CC.logit)
         if("Control" %in% sampleInfo$Group){
-            gp<-factor(sampleInfo$Group[match(colnames(CGI.limdat.CC.logit),sampleInfo$PlottingID)])
+            gp<-factor(sampleInfo$Group[match(colnames(CGI.limdat.CC.logit),sampleInfo$SampleID)])
             gp<-relevel(gp,ref="Control")}
         if("WT" %in% sampleInfo$Group){
-            gp<-factor(sampleInfo$Group[match(colnames(CGI.limdat.CC.logit),sampleInfo$PlottingID)])
+            gp<-factor(sampleInfo$Group[match(colnames(CGI.limdat.CC.logit),sampleInfo$SampleID)])
             gp<-relevel(gp,ref="WT")}
         design$Group<-as.numeric(gp)
         design$Intercept<-1

--- a/snakePipes/shared/rules/WGBS.snakefile
+++ b/snakePipes/shared/rules/WGBS.snakefile
@@ -539,7 +539,7 @@ if intList:
             output:
                 outFiles=run_int_aggStats(intList,sampleInfo)
             params:
-                auxshell=lambda wildcards,input:';'.join(['Rscript --no-save --no-restore ' + os.path.join(workflow_rscripts,'WGBSpipe.interval_stats.limma.R ') + os.path.join(outdir,'{}'.format(get_outdir("singleCpG_stats_limma"))) + ' ' + li +' '+ aui +' ' + os.path.join(outdir,input.Limdat) + ' '  + input.sampleInfo  for li,aui in zip(intList,[os.path.join(outdir,"aux_files",re.sub('.fa',re.sub('.bed','.CpGlist.bed',os.path.basename(x)),os.path.basename(refG))) for x in intList])])
+                auxshell=lambda wildcards,input:';'.join(['Rscript --no-save --no-restore ' + os.path.join(workflow_rscripts,'WGBSpipe.interval_stats.limma.R ') + os.path.join(outdir,'{}'.format(get_outdir("aggregate_stats_limma"))) + ' ' + li +' '+ aui +' ' + os.path.join(outdir,input.Limdat) + ' '  + input.sampleInfo  for li,aui in zip(intList,[os.path.join(outdir,"aux_files",re.sub('.fa',re.sub('.bed','.CpGlist.bed',os.path.basename(x)),os.path.basename(refG))) for x in intList])])
             log:
                 err="{}/logs/intAgg_stats.err".format(get_outdir("aggregate_stats_limma")),
                 out="{}/logs/intAgg_stats.out".format(get_outdir("aggregate_stats_limma"))

--- a/snakePipes/workflows/WGBS/cluster.yaml
+++ b/snakePipes/workflows/WGBS/cluster.yaml
@@ -12,3 +12,7 @@ conv_rate:
     memory: 6G
 CpG_stats:
     memory: 30G
+cleanup_metilene:
+    memory: 20G
+intAgg_stats:
+    memory: 30G


### PR DESCRIPTION
Renaming of samples via PlottingID was disabled. To be re-implemented at some point in the future.
Memory usage for aggregate statistics rules was increased.
One output path was corrected for aggregate stats rule.