### PR TITLE
Update to snakemake 5.2.3, so we don't need to modify the snakemake s…

### DIFF
--- a/bin/snakePipes
+++ b/bin/snakePipes
@@ -40,6 +40,9 @@ def parse_arguments():
                           'created conda environments. This will ignore what is already '
                           'in the workflow-specific yaml files and where conda is installed.')
 
+    createEnvsParser.add_argument('--only',
+                                  nargs='+',
+                                  help="If specified, a space-separated list of environments to create. This should typically only be done for testing purposes. The possible environments are: {}".format(cof.set_env_yamls().keys()))
     createEnvsParser.add_argument('--force',
                                   action='store_true',
                                   help='Force creation of conda environments, even if they apparently exist.')
@@ -179,6 +182,8 @@ def createCondaEnvs(args):
     cof.write_configfile(os.path.join(baseDir, "shared/defaults.yaml"), cf)
 
     for env in cof.set_env_yamls().values():
+        if args.only is not None and env not in args.only:
+            continue
         # Hash the file ala snakemake
         md5hash = hashlib.md5()
         md5hash.update(condaDirUse.encode())

--- a/bin/snakePipes
+++ b/bin/snakePipes
@@ -139,23 +139,6 @@ def fixSitePy(envPath):
         subprocess.check_call(cmd)
 
 
-def fixSnakemake(envPath):
-    """
-    Fix issue #916 in snakemake. This should eventually be removed before a real release.
-    """
-    for fname in glob.glob('{}/lib/python*/site-packages/snakemake/script.py'.format(envPath)):
-        f = open(fname).read()
-        lines = f.split('\n')
-        if 'path.startswith' in lines[237]:
-            lines[237] = '            if False:'
-            f = open(fname, "w")
-            f.write("\n".join(lines))
-            f.close()
-
-            cmd = [os.path.join(envPath, "bin", "python"), '-m', 'compileall', fname]
-            subprocess.check_call(cmd)
-
-
 def createCondaEnvs(args):
     """
     Create all of the conda environments
@@ -231,7 +214,6 @@ def createCondaEnvs(args):
     # Ignore site-packages in this env
     if args.noSitePackages:
         fixSitePy(rootDir)
-    fixSnakemake(rootDir)
 
 
 def main(args):

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: snakepipes
-  version: 1.0.0_beta1
+  version: 1.0.0_beta2
 
 source:
   path: ../
@@ -15,7 +15,7 @@ requirements:
     - python
   run:
     - python
-    - snakemake 5.2.0
+    - snakemake >=5.2.3
     - pandas
     - graphviz
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-snakemake >= 5.2.0
+snakemake >= 5.2.3
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 snakemake >= 5.2.3
+psutil
 pandas

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     description='Snakemake workflows and wrappers for NGS data processing from the MPI-IE',
     install_requires=[
         "snakemake >= 5.2.0",
+        "psutil",
         "pandas"
     ],
     zip_safe=False,

--- a/snakePipes/shared/rules/createIndices.snakefile
+++ b/snakePipes/shared/rules/createIndices.snakefile
@@ -151,13 +151,16 @@ rule bwaIndex:
 
 # Default memory allocation: 8G
 rule bwamethIndex:
-    input: genome_fasta
+    input:
+        genome_fasta,
+        genome_index
     output: os.path.join(outdir, "BWAmethIndex/genome.fa.bwameth.c2t.sa")
     params:
       genome = os.path.join(outdir, "BWAmethIndex", "genome.fa")
     conda: CondaEnvironment
     shell: """
-        ln -s {input} {params.genome}
+        ln -s {input[0]} {params.genome}
+        ln -s {input[1]} {params.genome}.fai
         bwameth.py index {params.genome}
         """
 

--- a/snakePipes/shared/rules/createIndices.snakefile
+++ b/snakePipes/shared/rules/createIndices.snakefile
@@ -151,16 +151,13 @@ rule bwaIndex:
 
 # Default memory allocation: 8G
 rule bwamethIndex:
-    input:
-        genome_fasta,
-        genome_index
+    input: genome_fasta
     output: os.path.join(outdir, "BWAmethIndex/genome.fa.bwameth.c2t.sa")
     params:
       genome = os.path.join(outdir, "BWAmethIndex", "genome.fa")
     conda: CondaEnvironment
     shell: """
         ln -s {input[0]} {params.genome}
-        ln -s {input[1]} {params.genome}.fai
         bwameth.py index {params.genome}
         """
 

--- a/snakePipes/shared/rules/envs/shared.yaml
+++ b/snakePipes/shared/rules/envs/shared.yaml
@@ -3,7 +3,7 @@ channels:
  - bioconda
  - conda-forge
 dependencies:
- - deeptools=3.1.0
+ - deeptools=3.1.2
  - seqtk=1.2
  - pigz=2.3.4
  - snpsplit=0.3.4
@@ -11,5 +11,5 @@ dependencies:
  - fastqc=0.11.7
  - cutadapt=1.16
  - trim-galore=0.4.5
- - sambamba=0.6.6
- - multiqc=1.5
+ - sambamba=0.6.8
+ - multiqc=1.6

--- a/snakePipes/shared/rules/envs/shared.yaml
+++ b/snakePipes/shared/rules/envs/shared.yaml
@@ -11,5 +11,5 @@ dependencies:
  - fastqc=0.11.7
  - cutadapt=1.16
  - trim-galore=0.4.5
- - sambamba=0.6.8
+ - sambamba=0.6.6
  - multiqc=1.6


### PR DESCRIPTION
…ourcecode any more. Bump to sambamba 0.6.8, which hasn't yet been released but supports more contigs. Bump multiQC version because newer is always better for MultiQC. Bump to beta 2, since this should be a new version once sambamba 0.6.8 comes out.