### PR TITLE
Bump STAR

### DIFF
--- a/snakePipes/shared/rules/envs/rna_seq.yaml
+++ b/snakePipes/shared/rules/envs/rna_seq.yaml
@@ -10,7 +10,7 @@ dependencies:
  - ucsc-gtftoGenepred=357
  - subread=1.6.1
  - hisat2=2.1.0
- - star=2.6.0c
+ - star=2.6.1b
  - salmon=0.9.1
  - r-base=3.4.1
  - r-wasabi=0.2

--- a/snakePipes/workflows/DNA-mapping/cluster.yaml
+++ b/snakePipes/workflows/DNA-mapping/cluster.yaml
@@ -1,7 +1,7 @@
 bamCoverage:
-    memory: 20G
+    memory: 4G
 bamCoverage_filtered:
-    memory: 20G  
+    memory: 4G  
 bamPE_fragment_size:
     memory: 10G
 bowtie2:

--- a/snakePipes/workflows/RNA-seq/defaults.yaml
+++ b/snakePipes/workflows/RNA-seq/defaults.yaml
@@ -45,7 +45,8 @@ salmon_index_options: --type quasi -k 31
 dnaContam: False
 ## supported mappers: STAR HISAT2
 mapping_prg: STAR
-star_options: --outBAMsortingBinsN 70
+## N.B., setting --outBAMsortingBinsN too high can result in cryptic errors
+star_options: --outBAMsortingBinsN 30
 hisat_options:
 verbose: False
 plot_format: png


### PR DESCRIPTION
Bump STAR to the most recent version, also decrease the default sorting bins. It turns out that increasing the number of threads causes problems with the sorting bins. Maybe we should pipe to samtools sort or sambamba for more predictable performance and fewer issues.