### PR TITLE
Fix #279

### DIFF
--- a/snakePipes/shared/rules/ATAC.snakefile
+++ b/snakePipes/shared/rules/ATAC.snakefile
@@ -15,7 +15,7 @@ rule filterFragments:
         --maxFragmentLength {params.cutoff}
         """
 
-# necessary for that MACS2 BAMPE fails, if there is just one fragment mapped
+# MACS2 BAMPE fails if there is just one fragment mapped
 rule filterCoveragePerScaffolds:
     input:
         bam = os.path.join(outdir_MACS2, "{sample}.short.bam")
@@ -29,9 +29,10 @@ rule filterCoveragePerScaffolds:
     threads: 6
     conda: CONDA_SHARED_ENV
     shell: """
-        sambamba index -t {threads} {input.bam} &&
-        samtools idxstats {input.bam} | awk -v cutoff={params.count_cutoff} \'$3 > cutoff\' | cut -f 1 > {output.whitelist} &&
-        sambamba view -t {threads} -f bam -o {output.bam} {input.bam} $(cat {output.whitelist} | paste -sd\' \')
+        samtools index -@ {threads} {input.bam}
+        samtools idxstats {input.bam} | awk -v cutoff={params.count_cutoff} \'$3 > cutoff\' | cut -f 1 > {output.whitelist}
+        samtools view -@ {threads} -bo {output.bam} {input.bam} $(cat {output.whitelist} | paste -sd\' \')
+        samtools index -@ {threads} {output.bam}
         """
 
 # MACS2 BAMPE filter: samtools view -b -f 2 -F 4 -F 8 -F 256 -F 512 -F 2048


### PR DESCRIPTION
This fixes #279 by using samtools rather than sambamba. It's a bit slower, but it works in more organisms. This will still fail if there are 20,000 contigs, since then we get to command line limits. At that point making a BED file of the white list is probably the only method that will reliably work.