### PR TITLE
Dev ksikora

### DIFF
--- a/docs/content/workflows/scRNA-seq.rst
+++ b/docs/content/workflows/scRNA-seq.rst
@@ -79,6 +79,8 @@ The default configuration file is listed below and can be found in `snakePipes/w
     verbose: False
     plot_format: pdf
     dnaContam: False
+    ## Parameters for th statistical analysis
+    cell_filter_metric: gene_universe
     #Option to skip RaceID to save time
     skipRaceID: False
 
@@ -179,8 +181,10 @@ Filtered_cells_monocle
 
 The poisson-rescaled count matrix is read and converted into a monocle dataset. A range of transcript counts per cell thresholds (from 1000 to 5000 by 500) are applied to filter cells and the resulting R objects are written to minT*.mono.set.RData. For every cell filtering threshold, several metrics are collected and written to metrics.tab.txt: number of retained cells, median number of expressed genes per cell (GPC), size of the total gene universe. Plots of median GPC as well as gene universe size as functions of the cell filtering threshold are written to medGPCvsminT.downscaled.png and gene_universevsminT.downscaled.png, respectively.
 
-The optimal cell filtering threshold for the subsequent analyses is selected as the value that results in the largest gene universe size. Gene expression dispersions are calculated for the corresponding monocle object and the trend plot is written to mono.set.*.disp.estim.png. A first iteration of cell clustering with default settings resutls in a rho-delta plot written to mono.set.*.rho_delta.png and a tSNE plot with cell cluster colouring written to mono.set.*.tsne.auto.Cluster.png. Rho and delta are now re-evaluated and set to the 80th and the 95th percentiles of the original distributions, respectively. Cells are reclustered and the corresponding tSNE plot is written to mono.set.*.tsne.thd.Cluster.png. The monocle object containing the updated clustering information is written to minT*.mono.set.RData. It is also converted to a seurat object and the clustering information is transferred. The seurat object is saved as minT*.seuset.RData. The tSNE plot with clustering information produced with seurat is written to minT*.seuset.tSNE.png.
+The optimal cell filtering threshold for the subsequent analyses is selected as the value that results in maximizing a gene expression metric choosable from "gene_universe" (default) and "medGPC". Using gene universe tends to maximize the overall cell diversity while using median genes per cell (medGPC) maximizes the information content per cell.
+Gene expression dispersions are calculated for the corresponding monocle object and the trend plot is written to mono.set.*.disp.estim.png. A first iteration of cell clustering with default settings resutls in a rho-delta plot written to mono.set.*.rho_delta.png and a tSNE plot with cell cluster colouring written to mono.set.*.tsne.auto.Cluster.png. Rho and delta are now re-evaluated and set to the 80th and the 95th percentiles of the original distributions, respectively. Cells are reclustered and the corresponding tSNE plot is written to mono.set.*.tsne.thd.Cluster.png. The monocle object containing the updated clustering information is written to minT*.mono.set.RData. It is also converted to a seurat object and the clustering information is transferred. The seurat object is saved as minT*.seuset.RData. The tSNE plot with clustering information produced with seurat is written to minT*.seuset.tSNE.png.
  Top10 as well as top2 markers are calculated for each cell cluster and written to minT*.Top10markers.txt and minT*.Top2markers.txt, respectively. The corresponding heatmaps are written to minT*.Top10markers.heatmap.png and minT*.Top2markers.heatmap.png, respectively. For the top2 marker list, violin as well as feature plots are produced and saved under Top2.clu*.violin.png and Top2.clu*.featurePlot.png, respectively. The R session info is written to sessionInfo.txt.
+Statistical procedures and results are summarized in Stats_report.html.
 
 Filtered_cells_RaceID
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -188,7 +192,7 @@ Filtered_cells_RaceID
 Cell filtering, metrics collection and threshold selection are done as above only using RaceID package functions, where applicable.
 
 Clustering is done with RaceID default settings. The fully processed RaceID object is written to sc.minT*.RData, the tsne plot with the clustering information to sc.minT*.tsne.clu.png.
-Top 10 and top 2 markers are calculated, and the resulting plots and tables written out as above. Violin and feature plots are generated for the top2 marker list and saved to files as in the description above. Session info is written to sessionInfo.txt
+Top 10 and top 2 markers are calculated, and the resulting plots and tables written out as above. Violin and feature plots are generated for the top2 marker list and saved to files as in the description above. Session info is written to sessionInfo.txt. Statistical procedures and results are summarized in Stats_report.html.
 
 
 Example images

--- a/snakePipes/shared/defaults.yaml
+++ b/snakePipes/shared/defaults.yaml
@@ -6,8 +6,7 @@
 # Note that due to limitations in yaml.dump, only very basic structures are
 # permitted here.
 ################################################################################
-#snakemake_options: ' --use-conda --conda-prefix /package/anaconda3/envs/ '
-snakemake_options: '--use-conda --conda-prefix /data/processing/sikora/snakePipes_envs'
+snakemake_options: ' --use-conda --conda-prefix /package/anaconda3/envs/ '
 tempdir: /data/extended/
 # The following are only needed if you use the --emailAddress option
 smtpServer:

--- a/snakePipes/shared/defaults.yaml
+++ b/snakePipes/shared/defaults.yaml
@@ -6,7 +6,8 @@
 # Note that due to limitations in yaml.dump, only very basic structures are
 # permitted here.
 ################################################################################
-snakemake_options: ' --use-conda --conda-prefix /package/anaconda3/envs/ '
+#snakemake_options: ' --use-conda --conda-prefix /package/anaconda3/envs/ '
+snakemake_options: '--use-conda --conda-prefix /data/processing/sikora/snakePipes_envs'
 tempdir: /data/extended/
 # The following are only needed if you use the --emailAddress option
 smtpServer:

--- a/snakePipes/shared/rscripts/scRNAseq_cell_filter_raceid.R
+++ b/snakePipes/shared/rscripts/scRNAseq_cell_filter_raceid.R
@@ -69,7 +69,7 @@ for(i in seq_along(minT)){
 
     metrics.tab$num_cells[i]<-ncol(sc@ndata)
     metrics.tab$gene_universe[i]<-length(sc@genes)
-    metrics.tab$medGPC[i]<-median(apply(sc@ndata[sc@genes,],2,function(X)sum(X>=minE,na.rm=TRUE)))
+    metrics.tab$medGPC[i]<-median(apply((sc@ndata*minTi)[sc@genes,],2,function(X)sum(X>=minE,na.rm=TRUE)))
 
 
 

--- a/snakePipes/shared/rscripts/scRNAseq_monocle_stats_report.Rmd
+++ b/snakePipes/shared/rscripts/scRNAseq_monocle_stats_report.Rmd
@@ -1,0 +1,88 @@
+---
+author: "`r Sys.info()[length(Sys.info())-1]`"
+date: "`r format(Sys.time(), '%d %B, %Y')`"
+output: 
+    html_document:
+        fig_caption: yes
+params:
+    outdir: "Stats_reports"
+    output_file: "Stats_reports/Stats_report.html"
+    metric: "gene_universe"
+title: "Monocle stats report"
+---
+
+This report summarizes statistical analyses of your single cell data stored in `r params$outdir`.    
+
+###Cell filtering
+
+The distribution of total transcript counts per cell (TPC) in unnormalized data was plotted.   
+
+```{r}
+knitr::include_graphics(file.path(params$outdir,"Expdata.ColumnSums.png"))
+```
+
+Cell filtering thresholds from 1000 through 5000 by 500 TPC were used to filter cells and count genes expressed in at least 4 cells at at least 2 counts (genes per cell, GPC). The total number of genes in the cell population was counted as number of rows in the filtered dataset.   
+
+The resulting counts were summarized for every threshold.   
+
+```{r}
+load(file.path(params$outdir,"metrics.tab.RData"))
+knitr::kable(metrics.tab)
+```
+
+```{r}
+knitr::include_graphics(file.path(params$outdir,"medGPCvsminT.downscaled.png"))
+knitr::include_graphics(file.path(params$outdir,"gene_universevsminT.downscaled.png"))
+
+```
+
+###Threshold selection
+
+Cell filtering threshold is selected such that the (first) maximum `r params$metric` is obtained. The underlying reasoning assumes that the maximum value of `r params$metric` retains  `r ifelse(params$metric %in% "gene_universe","most cell types in the data","cells with the highest information content")`. For the current dataset, `r gsub(".disp.estim.png","",gsub("mono.set.","",dir(params$outdir,pattern=".disp.estim.png",full.names=FALSE)))` TPC threshold-filtered data was further analyzed.
+
+###Cell clustering
+
+Negative binomial model was applied to untransformed counts and gene-wise dispersions were estimated and genes selected for unsupervised clustering highlighted. 
+
+```{r}
+knitr::include_graphics(dir(params$outdir,pattern="*.disp.estim.png",full.names=TRUE))
+```
+
+Tsne maps were calculated with default settings. Cell clustering was first run with default settings to generate a rho-delta plot. 
+
+```{r}
+knitr::include_graphics(dir(params$outdir,pattern="*.rho_delta.png",full.names=TRUE))
+```
+
+Rho and delta were then selected as the 0.8 and 0.95 percentile, respectively, and clustering was rerun using selected values as thresholds for cluster calling. Tsne plots with automated and recalculated threshold labels were plotted.
+
+```{r}
+b<-dir(params$outdir,pattern="*.tsne.auto.Cluster.png",full.names=TRUE)
+a<-dir(params$outdir,pattern="*.tsne.thd.Cluster.png",full.names=TRUE)
+knitr::include_graphics(c(b,a))
+```
+
+The resulting monocle object was then converted to a seurat object and cluster identities as well as tsne coordinates were copied over. A control tsne plot was generated.
+
+```{r}
+knitr::include_graphics(dir(params$outdir,pattern="*.seuset.tSNE.png",full.names=TRUE))
+```
+
+###Cluster marker discovery
+
+Top 10 and top 2 markers for each cluster were selected from genes differentially expressed between each cluster and the remaining cells using default settings. Obtained genes were reported in tables `r dir(params$outdir,pattern="*Top10markers.txt",full.names=FALSE)` and `r dir(params$outdir,pattern="*Top2markers.txt",full.names=FALSE)`, respectively.
+Gene expression of the genes from both lists was plotted on heatmaps. The heatmap of top2 cluster markers is plotted below.
+
+```{r}
+knitr::include_graphics(dir(params$outdir,pattern="*Top2markers.heatmap.png",full.names=TRUE))
+```
+
+For the top2 marker list, feature plots and violin plots were generated.
+
+
+```{r}
+fplot<-dir(params$outdir,pattern="*featurePlot.png",full.names=TRUE)
+vplot<-dir(params$outdir,pattern="*violin.png",full.names=TRUE)
+
+knitr::include_graphics(c(fplot,vplot))
+```

--- a/snakePipes/shared/rscripts/scRNAseq_monocle_stats_report.Rmd
+++ b/snakePipes/shared/rscripts/scRNAseq_monocle_stats_report.Rmd
@@ -84,5 +84,5 @@ For the top2 marker list, feature plots and violin plots were generated.
 fplot<-dir(params$outdir,pattern="*featurePlot.png",full.names=TRUE)
 vplot<-dir(params$outdir,pattern="*violin.png",full.names=TRUE)
 
-knitr::include_graphics(c(fplot,vplot))
+knitr::include_graphics(rbind(fplot,vplot))
 ```

--- a/snakePipes/shared/rscripts/scRNAseq_raceid_stats_report.Rmd
+++ b/snakePipes/shared/rscripts/scRNAseq_raceid_stats_report.Rmd
@@ -77,8 +77,8 @@ For the top2 marker list, feature plots and violin plots were generated.
 
 
 ```{r}
-fplot<-dir(params$outdir,pattern="*featurePlot.pdf",full.names=TRUE)
+fplot<-dir(params$outdir,pattern="*featurePlot.png",full.names=TRUE)
 vplot<-dir(params$outdir,pattern="*violin.png",full.names=TRUE)
 
-knitr::include_graphics(c(fplot,vplot))
+knitr::include_graphics(rbind(fplot,vplot))
 ```

--- a/snakePipes/shared/rscripts/scRNAseq_raceid_stats_report.Rmd
+++ b/snakePipes/shared/rscripts/scRNAseq_raceid_stats_report.Rmd
@@ -77,8 +77,14 @@ For the top2 marker list, feature plots and violin plots were generated.
 
 
 ```{r}
-fplot<-dir(params$outdir,pattern="*featurePlot.png",full.names=TRUE)
+png(file.path(params$outdir,"dummy_plot.png"))
+plot.new()
+dev.off()
+fplot1<-dir(params$outdir,pattern="Top1st.+featurePlot.png",full.names=TRUE)
+fplot2<-gsub("Top1st","Top2nd",fplot1)
+fplot2[!file.exists(fplot2)]<-file.path(params$outdir,"dummy_plot.png")
 vplot<-dir(params$outdir,pattern="*violin.png",full.names=TRUE)
 
-knitr::include_graphics(rbind(fplot,vplot))
+
+knitr::include_graphics(rbind(fplot1,fplot2,vplot))
 ```

--- a/snakePipes/shared/rscripts/scRNAseq_raceid_stats_report.Rmd
+++ b/snakePipes/shared/rscripts/scRNAseq_raceid_stats_report.Rmd
@@ -1,0 +1,84 @@
+---
+author: "`r Sys.info()[length(Sys.info())-1]`"
+date: "`r format(Sys.time(), '%d %B, %Y')`"
+output: 
+    html_document:
+        fig_caption: yes
+params:
+    outdir: "Stats_reports"
+    output_file: "Stats_reports/Stats_report.html"
+    metric: "gene_universe"
+title: "RaceID stats report"
+---
+
+This report summarizes statistical analyses of your single cell data stored in `r params$outdir`.    
+
+###Cell filtering
+
+The distribution of total transcript counts per cell (TPC) in unnormalized data was plotted.   
+
+```{r}
+knitr::include_graphics(file.path(params$outdir,"Expdata.ColumnSums.png"))
+```
+
+Cell filtering thresholds from 1000 through 5000 by 500 TPC were used to filter cells and count genes expressed in at least 4 cells at at least 2 counts (genes per cell, GPC). The total number of genes in the cell population was counted as number of rows in the filtered dataset.   
+
+The resulting counts were summarized for every threshold.   
+
+```{r}
+load(file.path(params$outdir,"metrics.tab.RData"))
+knitr::kable(metrics.tab)
+```
+
+```{r}
+knitr::include_graphics(file.path(params$outdir,"medGPCvsminT.downscaled.png"))
+knitr::include_graphics(file.path(params$outdir,"gene_universevsminT.downscaled.png"))
+
+```
+
+###Threshold selection
+
+Cell filtering threshold is selected such that the (first) maximum `r params$metric` is obtained. The underlying reasoning assumes that the maximum value of `r params$metric` retains  `r ifelse(params$metric %in% "gene_universe","most cell types in the data","cells with the highest information content")`. For the current dataset, `r gsub(".jaccard.png","",gsub("sc.minT","",dir(params$outdir,pattern=".jaccard.png",full.names=FALSE)))` TPC threshold-filtered data was further analyzed.
+
+###Cell clustering
+
+Cell-cell distances were calculated using the logpearson metric and selecting most highly variable genes (FSelect=TRUE). Clustering was performed with the default settings. 
+
+Jaccard metrics of the resulting clusters were plotted.
+
+```{r}
+knitr::include_graphics(dir(params$outdir,pattern="*jaccard.png",full.names=TRUE))
+```
+
+Tsne maps were calculated with default settings.
+
+Mean-Variance trend of finally processed dataset was plotted.
+
+```{r}
+knitr::include_graphics(dir(params$outdir,pattern="*MeanVar.png",full.names=TRUE))
+```
+
+Initial cell clusters were plotted on the tsne map.
+
+```{r}
+knitr::include_graphics(dir(params$outdir,pattern="*tsne.clu.png",full.names=TRUE))
+```
+
+###Cluster marker discovery
+
+Top 10 and top 2 markers for each cluster were selected from genes differentially expressed between each cluster and the remaining cells. Fold change of at least 2 and adjusted pvalue of less then 0.05 were required. Obtained genes were reported in tables `r dir(params$outdir,pattern="*Top10markers.txt",full.names=FALSE)` and `r dir(params$outdir,pattern="*Top2markers.txt",full.names=FALSE)`, respectively.
+Gene expression of the genes from both lists was plotted on heatmaps. The heatmap of top2 cluster markers is plotted below.
+
+```{r}
+knitr::include_graphics(dir(params$outdir,pattern="*Top2markers.heatmap.png",full.names=TRUE))
+```
+
+For the top2 marker list, feature plots and violin plots were generated.
+
+
+```{r}
+fplot<-dir(params$outdir,pattern="*featurePlot.pdf",full.names=TRUE)
+vplot<-dir(params$outdir,pattern="*violin.png",full.names=TRUE)
+
+knitr::include_graphics(c(fplot,vplot))
+```

--- a/snakePipes/shared/rscripts/scRNAseq_select_threshold_cluster_monocle.R
+++ b/snakePipes/shared/rscripts/scRNAseq_select_threshold_cluster_monocle.R
@@ -16,9 +16,11 @@ mtab<-commandArgs(trailingOnly=TRUE)[2]
 
 load(mtab)
 
-##select 'best' threshold
+metric<-commandArgs(trailingOnly=TRUE)[3]
 
-minTi<-metrics.tab$minT[which.max(metrics.tab$gene_universe)]
+##select 'best' threshold
+metrics.tab<-metrics.tab[order(metrics.tab$minT,decreasing=TRUE),]
+minTi<-metrics.tab$minT[which.max(metrics.tab[,metric])]
 
 load(paste0("minT",minTi,".mono.set.RData"))
 

--- a/snakePipes/shared/rscripts/scRNAseq_select_threshold_cluster_raceid.R
+++ b/snakePipes/shared/rscripts/scRNAseq_select_threshold_cluster_raceid.R
@@ -17,9 +17,11 @@ mtab<-commandArgs(trailingOnly=TRUE)[2]
 
 load(mtab)
 
-##select 'best' threshold
+metric<-commandArgs(trailingOnly=TRUE)[3]
 
-minTi<-metrics.tab$minT[which.max(metrics.tab$gene_universe)]
+##select 'best' threshold
+metrics.tab<-metrics.tab[order(metrics.tab$minT,decreasing=TRUE),]
+minTi<-metrics.tab$minT[which.max(metrics.tab[,metric])]
 
 load(paste0("sc.minT",minTi,".RData"))
 

--- a/snakePipes/shared/rscripts/scRNAseq_select_threshold_cluster_raceid.R
+++ b/snakePipes/shared/rscripts/scRNAseq_select_threshold_cluster_raceid.R
@@ -85,7 +85,8 @@ for(i in seq_along(unique(top2$Cluster))){
     plotdat$Cluster<-factor(plotdat$Cluster,levels=as.character(unique(plotdat$Cluster))[order(as.numeric(unique(plotdat$Cluster)))])
     ggplot(data=plotdat)+geom_violin(aes(x=Cluster,y=NormExpr,fill=Cluster))+geom_boxplot(aes(x=Cluster,y=NormExpr),width=0.1)+ggtitle(paste0("Cluster ",clu))+facet_wrap(~GeneID)
     ggsave(paste0("Top2.clu",clu,".violin.png"),width=12,height=6)
-    pdf(paste0("Top2.clu",clu,".featurePlot.pdf"),bg="white",onefile=TRUE)
+    png(paste0("Top2.clu",clu,".featurePlot.png"),bg="white",onefile=TRUE)
+    par(mfrow=c(1,2))
     plotexpmap(sc,g=rownames(subdat)[1],n=rownames(subdat)[1],logsc=TRUE,fr=FALSE)
     if(nrow(subdat)>1){
     plotexpmap(sc,g=rownames(subdat)[2],n=rownames(subdat)[2],logsc=TRUE,fr=FALSE)}

--- a/snakePipes/shared/rscripts/scRNAseq_select_threshold_cluster_raceid.R
+++ b/snakePipes/shared/rscripts/scRNAseq_select_threshold_cluster_raceid.R
@@ -85,12 +85,14 @@ for(i in seq_along(unique(top2$Cluster))){
     plotdat$Cluster<-factor(plotdat$Cluster,levels=as.character(unique(plotdat$Cluster))[order(as.numeric(unique(plotdat$Cluster)))])
     ggplot(data=plotdat)+geom_violin(aes(x=Cluster,y=NormExpr,fill=Cluster))+geom_boxplot(aes(x=Cluster,y=NormExpr),width=0.1)+ggtitle(paste0("Cluster ",clu))+facet_wrap(~GeneID)
     ggsave(paste0("Top2.clu",clu,".violin.png"),width=12,height=6)
-    png(paste0("Top2.clu",clu,".featurePlot.png"),bg="white",onefile=TRUE)
-    par(mfrow=c(1,2))
+    png(paste0("Top1st.clu",clu,".featurePlot.png"),bg="white")
     plotexpmap(sc,g=rownames(subdat)[1],n=rownames(subdat)[1],logsc=TRUE,fr=FALSE)
-    if(nrow(subdat)>1){
-    plotexpmap(sc,g=rownames(subdat)[2],n=rownames(subdat)[2],logsc=TRUE,fr=FALSE)}
     dev.off()
+    if(nrow(subdat)>1){
+    png(paste0("Top2nd.clu",clu,".featurePlot.png"),bg="white")
+    plotexpmap(sc,g=rownames(subdat)[2],n=rownames(subdat)[2],logsc=TRUE,fr=FALSE)
+    dev.off()}
+    
     
 }
 

--- a/snakePipes/workflows/scRNAseq/Snakefile
+++ b/snakePipes/workflows/scRNAseq/Snakefile
@@ -66,7 +66,8 @@ def run_RaceID(skipRaceID):
     if not skipRaceID:
         file_list = [
         "Filtered_cells_RaceID/metrics.tab.RData",
-        "Filtered_cells_RaceID/sessionInfo.txt"
+        "Filtered_cells_RaceID/sessionInfo.txt",
+        'Filtered_cells_RaceID/Stats_report.html'
         ]
         return(file_list)
     else:
@@ -128,7 +129,8 @@ rule all:
         run_deeptools_qc(),
         "deepTools_qc/bamPEFragmentSize/fragmentSize.metric.tsv",
         expand("deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",sample = samples),
-        "multiQC/multiqc_report.html"
+        "multiQC/multiqc_report.html",
+        'Filtered_cells_monocle/Stats_report.html'
 
 
 ### execute after workflow finished ############################################

--- a/snakePipes/workflows/scRNAseq/defaults.yaml
+++ b/snakePipes/workflows/scRNAseq/defaults.yaml
@@ -45,6 +45,8 @@ bw_binsize: 10
 verbose: False
 plot_format: pdf
 dnaContam: False
+## Parameters for th statistical analysis
+cell_filter_metric: gene_universe
 #Option to skip RaceID to save time
 skipRaceID: False
 ################################################################################

--- a/snakePipes/workflows/scRNAseq/scRNAseq
+++ b/snakePipes/workflows/scRNAseq/scRNAseq
@@ -19,7 +19,7 @@ import snakePipes.parserCommon as parserCommon
 def parse_args(defaults={"verbose": False, "configfile": None, "cluster_configfile": None, "max_jobs": 5, "snakemake_options": "--use-conda", "tempdir": None,
                          "downsample": False, "trim": False, "trim_options": "-a A{'30'}", "cell_names": None, "star_options": "--outBAMsortingBinsN 30 --twopassMode Basic",
                          "filter_annotation": "-v -P 'decay|pseudogene' ", "barcode_file": None, "barcode_pattern": "NNNNNNXXXXXX", "split_lib": False,
-                         "bw_binsize": 10, "plot_format": "png", "skipRaceID": False}):
+                         "bw_binsize": 10, "plot_format": "png", "cell_filter_metric": "gene_universe", "skipRaceID": False}):
     """
     Parse arguments from the command line.
     """
@@ -114,7 +114,15 @@ def parse_args(defaults={"verbose": False, "configfile": None, "cluster_configfi
                           metavar="STR",
                           type=str,
                           help="Format of the output plots from deeptools. Select 'none' for no plot (default: '%(default)s')",
-                          default=defaults["plot_format"])
+                          default=defaults["plot_format"]),
+
+    optional.add_argument("--cell_filter_metric",
+                          dest="cell_filter_metric",
+                          choices=['gene_universe', 'medGPC'],
+                          metavar="STR",
+                          type=str,
+                          help="The metric to maximise when selecting a cell filtering threshold (default: '%(default)s')",
+                          default=defaults["cell_filter_metric"])
 
     optional.add_argument("--skipRaceID",
                           dest="skipRaceID",


### PR DESCRIPTION
- stats reports were implemented for RaceID and Monocle/Seurat so that folders Filtered_cells_RaceID and Filtered_cells_monocle now contain a Stats_report.html.
- user can select a metric to maximize during cell filtering (cell_filter_metric, default: gene_universe)
- documentation has been updated
- for calculating median GPC, RaceID counts are  multiplied by the TPC threshold applied (similar to 'downscaling' in RaceID2)

