### PR TITLE
Dev ksikora

### DIFF
--- a/snakePipes/shared/rules/WGBS.snakefile
+++ b/snakePipes/shared/rules/WGBS.snakefile
@@ -212,7 +212,7 @@ rule get_ran_CG:
     log:
         err="aux_files/logs/get_ran_CG.err"
     threads: 1
-    conda: CONDA_PY27_ENV
+    conda: CONDA_SHARED_ENV
     shell: 'set +o pipefail; ' + os.path.join(workflow_tools,'methylCtools') + " fapos {input.refG}  " + re.sub('.gz','',"{output.pozF}") + ';cat '+ re.sub('.gz','',"{output.pozF}") +' | grep "+" -' + " | shuf | head -n 1000000 | awk {params.awkCmd}" + ' - | tr " " "\\t" | sort -k 1,1 -k2,2n - > ' + "{output.ranCG} 2>{log.err}"
 
 

--- a/snakePipes/shared/rules/envs/python27.yaml
+++ b/snakePipes/shared/rules/envs/python27.yaml
@@ -1,5 +1,0 @@
-name: py27Env-0.1.0
-channels:
-  - conda-forge
-dependencies:
-  - python=2.7

--- a/snakePipes/shared/tools/fapos.py
+++ b/snakePipes/shared/tools/fapos.py
@@ -146,4 +146,3 @@ def mod_fapos(sysargv):
 if __name__ == "__main__":
     import sys
     mod_fapos(sys.argv[1:])
-    

--- a/snakePipes/shared/tools/fapos.py
+++ b/snakePipes/shared/tools/fapos.py
@@ -140,10 +140,10 @@ def mod_fapos(sysargv):
 
     if args.qf:
         sys.stderr.write("%s end: position index generated\n" % nicetime())
+        sys.stderr.write("program version %s \n" % __version__)
 
 
 if __name__ == "__main__":
     import sys
     mod_fapos(sys.argv[1:])
-    from fapos import __version__
-    print('version' + __version__)
+    

--- a/snakePipes/shared/tools/fapos.py
+++ b/snakePipes/shared/tools/fapos.py
@@ -25,7 +25,7 @@ def mod_fapos(sysargv):
     def nicetime():
         return datetime.datetime.now().strftime("[fapos %Y-%m-%d %H:%M:%S]")
 
-    __version__="0.9.4"
+    __version__ = "0.9.4"
 
     #######################################
     # arguments, filehandles
@@ -145,4 +145,5 @@ def mod_fapos(sysargv):
 if __name__ == "__main__":
     import sys
     mod_fapos(sys.argv[1:])
+    from fapos import __version__
     print('version' + __version__)

--- a/snakePipes/shared/tools/fapos.py
+++ b/snakePipes/shared/tools/fapos.py
@@ -25,10 +25,12 @@ def mod_fapos(sysargv):
     def nicetime():
         return datetime.datetime.now().strftime("[fapos %Y-%m-%d %H:%M:%S]")
 
+    __version__="0.9.4"
+
     #######################################
     # arguments, filehandles
 
-    parser = argparse.ArgumentParser(prog="methylCtools fapos", version="0.9.4", description="creates cytosine position index for defined context")
+    parser = argparse.ArgumentParser(prog="methylCtools fapos", description="creates cytosine position index for defined context")
     parser.add_argument("-s", "--silent", dest="qf", action="store_false", help="do not show status messages")
 
     groupinput = parser.add_argument_group("input files, required")

--- a/snakePipes/shared/tools/fapos.py
+++ b/snakePipes/shared/tools/fapos.py
@@ -145,3 +145,4 @@ def mod_fapos(sysargv):
 if __name__ == "__main__":
     import sys
     mod_fapos(sys.argv[1:])
+    print('version' + __version__)


### PR DESCRIPTION
Moved 'version' to __version__ in fapos.py, this removes the last incompatibility with python3 sothat the python2.7 env is not needed anymore. Removed the corresponding yaml