### PR TITLE
two bugfixes

### DIFF
--- a/snakePipes/shared/rules/Bowtie2.snakefile
+++ b/snakePipes/shared/rules/Bowtie2.snakefile
@@ -22,7 +22,7 @@ if paired:
             -X {params.insert_size_max} \
             -x {params.bowtie2_index} -1 {input.r1} -2 {input.r2} \
             {params.bowtie_opts} {params.mate_orientation} \
-            --rg-id {wildcards.sample} --rg CN:mpi-ie_deep_sequencing_unit \
+            --rg-id {wildcards.sample} \
             --rg DS:{wildcards.sample} --rg PL:ILLUMINA --rg SM:{wildcards.sample} \
             -p {threads} \
             2> {output.align_summary} | \
@@ -49,7 +49,7 @@ else:
             bowtie2 \
             -x {params.bowtie2_index} -U {input} \
             {params.bowtie_opts} \
-            --rg-id {wildcards.sample} --rg CN:mpi-ie_deep_sequencing_unit \
+            --rg-id {wildcards.sample} \
             --rg DS:{wildcards.sample} --rg PL:ILLUMINA --rg SM:{wildcards.sample} \
             -p {threads} \
             2> {output.align_summary} | \

--- a/snakePipes/shared/rules/Bowtie2_allelic.snakefile
+++ b/snakePipes/shared/rules/Bowtie2_allelic.snakefile
@@ -33,7 +33,7 @@ if mapping_prg == "Bowtie2":
                 -X {params.insert_size_max} \
                 -x {params.idxbase} -1 {input.r1} -2 {input.r2} \
                 {params.bowtie_opts} {params.mate_orientation} \
-                --rg-id {wildcards.sample} --rg CN:mpi-ie_deep_sequencing_unit \
+                --rg-id {wildcards.sample} \
                 --rg DS:{wildcards.sample} --rg PL:ILLUMINA --rg SM:{wildcards.sample} \
                 -p {threads} \
                 2> {output.align_summary} | \
@@ -62,7 +62,7 @@ if mapping_prg == "Bowtie2":
                 -x {params.idxbase} -U {input.r1} \
                 --reorder \
                 {params.bowtie_opts} \
-                --rg-id {wildcards.sample} --rg CN:mpi-ie_deep_sequencing_unit \
+                --rg-id {wildcards.sample} \
                 --rg DS:{wildcards.sample} --rg PL:ILLUMINA --rg SM:{wildcards.sample} \
                 -p {threads} \
                 2> {output.align_summary} | \

--- a/snakePipes/shared/rules/umi_tools.snakefile
+++ b/snakePipes/shared/rules/umi_tools.snakefile
@@ -85,7 +85,7 @@ else:
             bamfile = "filtered_bam/{sample}.filtered.bam"
         conda: CONDA_SHARED_ENV
         shell: """
-            ln -s -r {input.bamfile} {output.bamfile}
+            mv {input.bamfile} {output.bamfile}
             """
 
 rule samtools_index_filtered:

--- a/snakePipes/workflows/DNA-mapping/cluster.yaml
+++ b/snakePipes/workflows/DNA-mapping/cluster.yaml
@@ -5,7 +5,7 @@ bamCoverage_filtered:
 bamPE_fragment_size:
     memory: 10G
 bowtie2:
-    memory: 1G
+    memory: 4G
 CollectAlignmentSummaryMetrics:
     memory: 2G
 CollectInsertSizeMetrics:

--- a/snakePipes/workflows/DNA-mapping/defaults.yaml
+++ b/snakePipes/workflows/DNA-mapping/defaults.yaml
@@ -52,7 +52,7 @@ properpairs: false
 mate_orientation: --fr
 ## other Bowtie2 stuff
 insert_size_max: 1000
-bowtie_opts:
+bowtie_opts: --rg CN:mpi-ie_deep_sequencing_unit
 umibarcode: False
 bcpattern: NNNNCCCCCCCC #default: 4 base umi barcode, 8 base cell barcode (eg. RELACS barcode)
 umidedup: False


### PR DESCRIPTION
fixed: `samtools sort` asks 2G memory but default.yaml allocated only 1GB
fixed: `--umidedup` feature leads to broken links of filtered_bam files