### PR TITLE
Trying to fix r-rmarkdown issue with snakemake 'knit_root_dir' ignore…

### DIFF
--- a/snakePipes/shared/rules/envs/wgbs.yaml
+++ b/snakePipes/shared/rules/envs/wgbs.yaml
@@ -11,7 +11,7 @@ dependencies:
   - r-car = 3.0_2
   - r-factominer = 1.41
   - r-ggplot2 = 3.1.0
-  - r-rmarkdown
+  - r-rmarkdown >= 2.0
   - r-dplyr = 0.8.0.1
   - r-tidyr
   - r-pander


### PR DESCRIPTION
It fixes an issue with rmarkdown crashing during QC reports rules of the WGBS pipeline. Before this patch, rmarkdown 0.9.3 is installed by default, which doesn't take into account snakemake's `knit_root_dir` parameter passed to `rmarkdown::render`.  

This patch should fix it (I also encountered errors about htmltools and yaml packages that are ̀installed by an R version with different internals; it needs to be reinstalled for use with this R version`, I'm not sure this patch fixes that).