### PR TITLE
Implement #489, check for chromosome name consistency when creating indices

### DIFF
--- a/.ci_stuff/test_dag.sh
+++ b/.ci_stuff/test_dag.sh
@@ -146,8 +146,8 @@ if [ ${PIPESTATUS[0]} -ne 0 ] || [ $WC -ne 488 ]; then exit 1 ; fi
 
 # createIndices
 WC=`createIndices -o output --snakemakeOptions " --dryrun --conda-prefix /tmp" --genome ftp://ftp.ensembl.org/pub/release-93/fasta/mus_musculus/dna/Mus_musculus.GRCm38.dna_sm.primary_assembly.fa.gz --gtf ftp://ftp.ensembl.org/pub/release-93/gtf/mus_musculus/Mus_musculus.GRCm38.93.gtf.gz blah | tee >(cat 1>&2) | grep -v "Conda environment" | wc -l`
-if [ ${PIPESTATUS[0]} -ne 0 ] || [ $WC -ne 144 ]; then exit 1 ; fi
+if [ ${PIPESTATUS[0]} -ne 0 ] || [ $WC -ne 143 ]; then exit 1 ; fi
 WC=`createIndices -o output --snakemakeOptions " --dryrun --conda-prefix /tmp" --genome ftp://ftp.ensembl.org/pub/release-93/fasta/mus_musculus/dna/Mus_musculus.GRCm38.dna_sm.primary_assembly.fa.gz --gtf ftp://ftp.ensembl.org/pub/release-93/gtf/mus_musculus/Mus_musculus.GRCm38.93.gtf.gz --rmskURL http://hgdownload.soe.ucsc.edu/goldenPath/dm6/database/rmsk.txt.gz blah | tee >(cat 1>&2) | grep -v "Conda environment" | wc -l`
-if [ ${PIPESTATUS[0]} -ne 0 ] || [ $WC -ne 151 ]; then exit 1 ; fi
+if [ ${PIPESTATUS[0]} -ne 0 ] || [ $WC -ne 150 ]; then exit 1 ; fi
 
 rm -rf SE_input PE_input BAM_input output /tmp/genes.gtf /tmp/genome.fa /tmp/genome.fa.fai

--- a/snakePipes/shared/rules/createIndices.snakefile
+++ b/snakePipes/shared/rules/createIndices.snakefile
@@ -92,12 +92,35 @@ rule gtf2BED:
         """
 
 # Default memory allocation: 1G
+# As a side effect, this checks the GTF and fasta file for chromosome name consistency (it will pass if at least 1 chromosome name is shared)
 rule extendCodingRegions:
-    input: genes_gtf
+    input: genes_gtf, genome_index
     output: extended_coding_regions_gtf
     shell: """
         grep -v "^#" {input} | awk 'BEGIN{{FS="\t"; OFS="\t"}}{{if($3 == "gene" || $3 == "transcript") {{$4 -= 500; $5 += 500; if($4 < 1) {{$4 = 1}}; print}}}}' > {output}
         """
+    run:
+        faiChroms = set()
+        for line in open(input[1]):
+            cols = line.strip().split()
+            faiChroms.add(cols[0])
+
+        gtfChroms = set()
+        o = open(output[0], "w")
+        for line in open(input[0]):
+            if line.startswith("#"):
+                continue
+            cols = line.strip().split("\t")
+            gtfChroms.add(cols[0])
+            if cols[2] == "gene" or cols[2] == "transcript":
+                cols[3] = str(max(1, int(cols[3] - 500)))
+                cols[4] = str(int(cols[4]) + 500)
+            o.write("\t".join(cols))
+            o.write("\n")
+        o.close()
+
+        # Ensure there is at least one shared chromosome name between the annotation and fasta file
+        assert faiChroms.intersection(gtfChroms) >= 1
 
 
 # Default memory allocation: 20G


### PR DESCRIPTION
This will kill createIndices if there is not at least 1 chromosome name shared between the fasta and GTF file.