### PR TITLE
Expand ATAC, implement #553

### DIFF
--- a/.ci_stuff/test_dag.sh
+++ b/.ci_stuff/test_dag.sh
@@ -70,6 +70,8 @@ if [ ${PIPESTATUS[0]} -ne 0 ] || [ $WC -ne 854 ]; then exit 1 ; fi
 # ChIP-seq
 WC=`ChIP-seq -d BAM_input --snakemakeOptions " --dryrun --conda-prefix /tmp" .ci_stuff/organism.yaml .ci_stuff/ChIP.sample_config.yaml | tee >(cat 1>&2) | grep -v "Conda environment" | wc -l`
 if [ ${PIPESTATUS[0]} -ne 0 ] || [ $WC -ne 270 ]; then exit 1 ; fi
+WC=`ChIP-seq -d BAM_input --snakemakeOptions " --dryrun --conda-prefix /tmp" --peakCaller Genrich .ci_stuff/organism.yaml .ci_stuff/ChIP.sample_config.yaml | tee >(cat 1>&2) | grep -v "Conda environment" | wc -l`
+if [ ${PIPESTATUS[0]} -ne 0 ] || [ $WC -ne 224 ]; then exit 1 ; fi
 WC=`ChIP-seq -d BAM_input --snakemakeOptions " --dryrun --conda-prefix /tmp" --singleEnd .ci_stuff/organism.yaml .ci_stuff/ChIP.sample_config.yaml | tee >(cat 1>&2) | grep -v "Conda environment" | wc -l`
 if [ ${PIPESTATUS[0]} -ne 0 ] || [ $WC -ne 270 ]; then exit 1 ; fi
 WC=`ChIP-seq -d BAM_input --snakemakeOptions " --dryrun --conda-prefix /tmp" --bigWigType log2ratio .ci_stuff/organism.yaml .ci_stuff/ChIP.sample_config.yaml | tee >(cat 1>&2) | grep -v "Conda environment" | wc -l`
@@ -81,6 +83,10 @@ if [ ${PIPESTATUS[0]} -ne 0 ] || [ $WC -ne 664 ]; then exit 1 ; fi
 # ATAC-seq
 WC=`ATAC-seq -d BAM_input --snakemakeOptions " --dryrun --conda-prefix /tmp" .ci_stuff/organism.yaml | tee >(cat 1>&2) | grep -v "Conda environment" | wc -l`
 if [ ${PIPESTATUS[0]} -ne 0 ] || [ $WC -ne 337 ]; then exit 1 ; fi
+WC=`ATAC-seq -d BAM_input --snakemakeOptions " --dryrun --conda-prefix /tmp" --peakCaller Genrich .ci_stuff/organism.yaml | tee >(cat 1>&2) | grep -v "Conda environment" | wc -l`
+if [ ${PIPESTATUS[0]} -ne 0 ] || [ $WC -ne 347 ]; then exit 1 ; fi
+WC=`ATAC-seq -d BAM_input --snakemakeOptions " --dryrun --conda-prefix /tmp" --peakCaller HMMRATAC .ci_stuff/organism.yaml | tee >(cat 1>&2) | grep -v "Conda environment" | wc -l`
+if [ ${PIPESTATUS[0]} -ne 0 ] || [ $WC -ne 402 ]; then exit 1 ; fi
 WC=`ATAC-seq -d BAM_input --snakemakeOptions " --dryrun --conda-prefix /tmp" --maxFragmentSize 120 --qval 0.1 .ci_stuff/organism.yaml | tee >(cat 1>&2) | grep -v "Conda environment" | wc -l`
 if [ ${PIPESTATUS[0]} -ne 0 ] || [ $WC -ne 337 ]; then exit 1 ; fi
 WC=`ATAC-seq -d BAM_input --snakemakeOptions " --dryrun --conda-prefix /tmp" --fromBAM BAM_input/filtered_bam/ .ci_stuff/organism.yaml | tee >(cat 1>&2) | grep -v "Conda environment" | wc -l`

--- a/docs/content/workflows/ATAC-seq.rst
+++ b/docs/content/workflows/ATAC-seq.rst
@@ -47,7 +47,7 @@ If the user provides additional columns between 'name' and 'condition' in the sa
 
 The differential binding module utilizes the R package `CSAW <https://bioconductor.org/packages/release/bioc/html/csaw.html>`__ to detect significantly different peaks between two conditions.
 The analysis is performed on a union of peaks from all samples mentioned in the sample sheet. 
-This merged set of regions are provided as an output inside the **CSAW_sampleSheet** folder as the file 'DiffBinding_allregions.bed'. 
+This merged set of regions are provided as an output inside the **CSAW_MACS2_sampleSheet** folder as the file 'DiffBinding_allregions.bed'. 
 All differentially bound regions are available in 'CSAW/DiffBinding_significant.bed' . 
 Two thresholds are applied to produce ``Filtered.results.bed`` : FDR (default ``0.05`` ) as well as absolute log fold change (``1``). These can be specified either in the defaults.yaml dictionary or via commandline parameters '--FDR' and '--LFC'. Additionally, filtered results are split into up to 3 bed files, representing direction change (UP, DOWN, or MIXED).
 
@@ -82,6 +82,8 @@ There is a configuration file in ``snakePipes/workflows/ATACseq/defaults.yaml``:
     maxFragmentSize: 150
     minFragmentSize: 0
     verbose: false
+    ## which peak caller to use
+    peakCaller: 'MACS2'
     # sampleSheet_DB
     sampleSheet:
     # windowSize
@@ -119,7 +121,7 @@ Understanding the outputs
 Assuming a sample sheet is used, the following will be **added** to the working directory::
 
     .
-    ├── CSAW_sampleSheet
+    ├── CSAW_MACS2_sampleSheet
     │   ├── CSAW.log
     │   ├── CSAW.session_info.txt
     │   ├── DiffBinding_allregions.bed
@@ -134,6 +136,14 @@ Assuming a sample sheet is used, the following will be **added** to the working 
     │   └── plotFingerprint
     │       ├── plotFingerprint.metrics.txt
     │       └── plotFingerprint.png
+    ├── Genrich
+    │   └── group1.narrowPeak
+    ├── HMMRATAC
+    │   ├── sample1.log
+    │   ├── sample1.model
+    │   ├── sample1_peaks.gappedPeak
+    │   ├── sample1_summits.bed
+    │   └── sample1_training.bed
     ├── MACS2
     │   ├── sample1.filtered.BAM_control_lambda.bdg
     │   ├── sample1.filtered.BAM_peaks.narrowPeak
@@ -151,8 +161,10 @@ Assuming a sample sheet is used, the following will be **added** to the working 
         ├── sample1.filtered.BAM_peaks.qc.txt
         └── sample2.filtered.BAM_peaks.qc.txt
 
-Currently the ATAC-seq workflow performs detection of open chromatin regions via `MACS2 <https://github.com/taoliu/MACS>`__, and if a sample sheet is provided, the detection of differential open chromatin sites via `CSAW <https://bioconductor.org/packages/release/bioc/html/csaw.html>`__. There are additionally log files in most of the directories. The various outputs are documented in the CSAW and MACS2 documentation.
-For more information on the contents of the **CSAW_sampleSheet** folder, see section :ref:`diffOpenChrom` .
+Currently the ATAC-seq workflow performs detection of open chromatin regions via `MACS2 <https://github.com/taoliu/MACS>`__ (or `HMMRATAC <https://academic.oup.com/nar/article/47/16/e91/5519166>`__ or `Genrich <https://github.com/jsh58/Genrich>`__, if specified with ``--peakCaller``), and if a sample sheet is provided, the detection of differential open chromatin sites via `CSAW <https://bioconductor.org/packages/release/bioc/html/csaw.html>`__. There are additionally log files in most of the directories. The various outputs are documented in the CSAW and MACS2 documentation.
+For more information on the contents of the **CSAW_MACS2_sampleSheet** folder, see section :ref:`diffOpenChrom` .
+
+* **MACS2** / **HMMRATAC** / **Genrich**: Contains peaks found by the peak caller. The most useful files end in ``.narrowPeak`` or ``.gappedPeak`` and are appropriate for visualization in IGV.
 
 * **MACS2_QC**: contains a number of QC metrics that we find useful, namely :
     * the number of peaks
@@ -161,7 +173,9 @@ For more information on the contents of the **CSAW_sampleSheet** folder, see sec
 
 * **deepTools_ATAC**: contains the output of `plotFingerPrint <https://deeptools.readthedocs.io/en/develop/content/tools/plotFingerprint.html>`__, which is a useful QC plot to assess signal enrichment between the ATAC-seq samples.
 
-.. note:: The ``_sampleSheet`` suffix for the ``CSAW_sampleSheet`` is drawn from the name of the sample sheet you use. So if you instead named the sample sheet ``mySampleSheet.txt`` then the folder would be named ``CSAW_mySampleSheet``. This facilitates using multiple sample sheets.
+.. note:: The ``_sampleSheet`` suffix for the ``CSAW_MACS2_sampleSheet`` is drawn from the name of the sample sheet you use. So if you instead named the sample sheet ``mySampleSheet.txt`` then the folder would be named ``CSAW_mySampleSheet``. This facilitates using multiple sample sheets. Similarly, ``_MACS2`` portion will be different if you use HMMRATAC or Genrich for peak calling.
+
+.. note:: The output from Genrich will be peaks called per-group if you specify a sample sheet. This is because Genrich is capable of directly using replicates during peak calling.
 
 
 Where to find final bam files and biwgwigs

--- a/docs/content/workflows/ChIP-seq.rst
+++ b/docs/content/workflows/ChIP-seq.rst
@@ -122,6 +122,8 @@ There is a configuration file in ``snakePipes/workflows/ChIP-seq/defaults.yaml``
     ## preconfigured target genomes (mm9,mm10,dm3,...) , see /path/to/snakemake_workflows/shared/organisms/
     ## Value can be also path to your own genome config file!
     genome:
+    ## Which peak caller should be used?
+    peakCaller: 'MACS2'
     ## paired end data?
     pairedEnd: true
     ## Bin size of output files in bigWig format
@@ -165,6 +167,8 @@ The ChIP-seq pipeline will generate additional output as follows::
     │   ├── sample2.filtered.histoneHMM-zinba-emfit.pdf
     │   ├── sample2.filtered.histoneHMM-zinba-params-em.RData
     │   └── sample2.filtered.histoneHMM-zinba-params-em.txt
+    ├── Genrich
+    │   └── sample2.narrowPeak
     └── MACS2
         ├── sample1.filtered.BAM_peaks.narrowPeak
         ├── sample1.filtered.BAM_peaks.qc.txt
@@ -187,7 +191,9 @@ Following up on the DNA-mapping module results (see :doc:`DNA-mapping`), the wor
 
 * **deepTools_ChIP**: Contains output from two of the deepTools modules. The `bamCompare <https://deeptools.readthedocs.io/en/develop/content/tools/bamCompare.html>`__ output contains the input-normalized coverage files for the samples, which is very useful for downstream analysis, such as visualization in IGV and plotting the heatmaps. The `plotFingerPrint <https://deeptools.readthedocs.io/en/develop/content/tools/plotFingerprint.html>`__ output is a useful QC plot to assess signal enrichment in the ChIP samples.
 
-* **MACS2**: This folder contains the output of `MACS2 <https://github.com/taoliu/MACS>`__ on the ChIP samples, MACS2 would perform either a **narrow** or **broad** peak calling on the samples, as indicated by the ChIP sample configuration file (see :ref:`ChIPconfig`). The outputs files would contain the respective tags (**narrowPeak** or **broadPeak**).
+* **Genrich**: This folder contains the output of `Genrich <https://github.com/jsh58/Genrich>`__. This will only exist IF you specified ``--peakCaller Genrich`` and you have samples with non-broad peaks. The output is in narrowPeak format, like that from MACS2.
+
+* **MACS2**: This folder contains the output of `MACS2 <https://github.com/taoliu/MACS>`__ on the ChIP samples, MACS2 would perform either a **narrow** or **broad** peak calling on the samples, as indicated by the ChIP sample configuration file (see :ref:`ChIPconfig`). The outputs files would contain the respective tags (**narrowPeak** or **broadPeak**). This folder will only exist if you have non-broad marks and use MACS2 for peak calling
 
 * **histoneHMM**: This folder contains the output of `histoneHMM <https://github.com/matthiasheinig/histoneHMM>`__. This folder will only exist if you have broad marks.
 
@@ -197,6 +203,8 @@ Following up on the DNA-mapping module results (see :doc:`DNA-mapping`), the wor
 .. note:: Although in case of broad marks, we also perform the MACS2 `broadpeak` analysis (output available as ``MACS2/<sample>.filtered.BAM_peaks.broadPeak``), we would recommend using the histoneHMM outputs in these cases, since histoneHMM produces better results than MACS2 for broad peaks.
 
 .. note:: The ``_sampleSheet`` suffix for the ``CSAW_sampleSheet`` is drawn from the name of the sample sheet you use. So if you instead named the sample sheet ``mySampleSheet.txt`` then the folder would be named ``CSAW_mySampleSheet``. This facilitates using multiple sample sheets.
+
+.. node:: At the moment Genrich is NOT jointly calling peaks within a group since it's not aware of which samples contain which antibody. It is utilizing the input control if one exists.
 
 
 Command line options

--- a/docs/content/workflows/ChIP-seq.rst
+++ b/docs/content/workflows/ChIP-seq.rst
@@ -204,7 +204,7 @@ Following up on the DNA-mapping module results (see :doc:`DNA-mapping`), the wor
 
 .. note:: The ``_sampleSheet`` suffix for the ``CSAW_sampleSheet`` is drawn from the name of the sample sheet you use. So if you instead named the sample sheet ``mySampleSheet.txt`` then the folder would be named ``CSAW_mySampleSheet``. This facilitates using multiple sample sheets.
 
-.. node:: At the moment Genrich is NOT jointly calling peaks within a group since it's not aware of which samples contain which antibody. It is utilizing the input control if one exists.
+.. note:: At the moment Genrich is NOT jointly calling peaks within a group since it's not aware of which samples contain which antibody. It is utilizing the input control if one exists.
 
 
 Command line options

--- a/snakePipes/common_functions.py
+++ b/snakePipes/common_functions.py
@@ -198,14 +198,14 @@ def sampleSheetGroups(sampleSheet):
     """
     f = open(sampleSheet)
     conditionCol = None
-    nameCole = None
+    nameCol = None
     nCols = None
     d = dict()
     for idx, line in enumerate(f):
         cols = line.strip().split("\t")
         if idx == 0:
             if "condition" not in cols or "name" not in cols:
-                sys.exit("ERROR: Please use 'name' and 'condition' as column headers in the sample info file ({})!\n".format(sample_info_file))
+                sys.exit("ERROR: Please use 'name' and 'condition' as column headers in the sample info file ({})!\n".format(sampleSheet))
             conditionCol = cols.index("condition")
             nameCol = cols.index("name")
             nCols = len(cols)
@@ -213,7 +213,7 @@ def sampleSheetGroups(sampleSheet):
         elif idx == 1:
             # Sometimes there's a column of row names, which lack a header
             if len(cols) != nCols and len(cols) - 1 != nCols:
-                sys.exit("ERROR: there's a mismatch between the number of columns in the header and body of {}!\n".format(sample_info_file))
+                sys.exit("ERROR: there's a mismatch between the number of columns in the header and body of {}!\n".format(sampleSheet))
             if len(cols) - 1 == nCols:
                 conditionCol += 1
                 nameCol += 1

--- a/snakePipes/common_functions.py
+++ b/snakePipes/common_functions.py
@@ -192,6 +192,39 @@ def check_replicates(sample_info_file):
     return True
 
 
+def sampleSheetGroups(sampleSheet):
+    """
+    Parse a sampleSheet and return a dictionary with keys the group and values the sample names
+    """
+    f = open(sampleSheet)
+    conditionCol = None
+    nameCole = None
+    nCols = None
+    d = dict()
+    for idx, line in enumerate(f):
+        cols = line.strip().split("\t")
+        if idx == 0:
+            if "condition" not in cols or "name" not in cols:
+                sys.exit("ERROR: Please use 'name' and 'condition' as column headers in the sample info file ({})!\n".format(sample_info_file))
+            conditionCol = cols.index("condition")
+            nameCol = cols.index("name")
+            nCols = len(cols)
+            continue
+        elif idx == 1:
+            # Sometimes there's a column of row names, which lack a header
+            if len(cols) != nCols and len(cols) - 1 != nCols:
+                sys.exit("ERROR: there's a mismatch between the number of columns in the header and body of {}!\n".format(sample_info_file))
+            if len(cols) - 1 == nCols:
+                conditionCol += 1
+                nameCol += 1
+        if not len(line.strip()) == 0:
+            if cols[conditionCol] not in d:
+                d[cols[conditionCol]] = []
+            d[cols[conditionCol]].append(cols[nameCol])
+    f.close()
+    return d
+
+
 def make_temp_dir(tempDir, fallback_dir, verbose=False):
     try:
         output = subprocess.check_output("mktemp -d -p " + tempDir + "/ tmp.snakemake.XXXXXXXX", shell=True, stderr=subprocess.STDOUT)

--- a/snakePipes/shared/rules/ATAC.snakefile
+++ b/snakePipes/shared/rules/ATAC.snakefile
@@ -17,6 +17,7 @@ rule filterFragments:
         --minFragmentLength {params.minFragmentSize}
         """
 
+
 rule filterMetricsToHtml:
     input: 
         expand(os.path.join(outdir_MACS2, "{sample}.short.metrics"), sample=samples)
@@ -50,6 +51,7 @@ rule filterCoveragePerScaffolds:
         samtools index -@ {threads} {output.bam}
         """
 
+
 # MACS2 BAMPE filter: samtools view -b -f 2 -F 4 -F 8 -F 256 -F 512 -F 2048
 rule callOpenChromatin:
     input:
@@ -79,4 +81,51 @@ rule callOpenChromatin:
             --qvalue {params.qval_cutoff} \
             {params.nomodel} \
             {params.write_bdg} > {log.out} 2> {log.err}
+        """
+
+
+rule tempChromSizes:
+    input: genome_index
+    output: temp("HMMRATAC/chrom_sizes")
+    shell: """
+        cut -f 1,2 {input} > {output}
+        """
+
+
+# TODO: -q MINMAPQ -Xmx value is currently hard-coded
+# Actually uses 2-4 cores, even though there's no option for it!
+# Requires PE data
+rule HMMRATAC_peaks:
+    input:
+        "filtered_bam/{sample}.filtered.bam",
+        "filtered_bam/{sample}.filtered.bam.bai",
+        "HMMRATAC/chrom_sizes"
+    output:
+        "HMMRATAC/{sample}.log",
+        "HMMRATAC/{sample}.model",
+        "HMMRATAC/{sample}_peaks.gappedPeak",
+        "HMMRATAC/{sample}_summits.bed",
+        "HMMRATAC/{sample}_training.bed"
+    params:
+        blacklist = "-e {}".format(blacklist_bed) if blacklist_bed else ""
+    conda: CONDA_ATAC_ENV
+    threads: 4
+    shell: """
+        HMMRATAC -Xmx10G -b {input[0]} -i {input[1]} -g {input[2]} {params.blacklist} -o HMMRATAC/{wildcards.sample}
+        """
+
+
+# Requires PE data
+# Should be run once per-group!
+rule Genrich_peaks:
+    input:
+        bams=lambda wildcards: expand(os.path.join(outdir_MACS2 + "/{sample}.short.cleaned.bam"), sample=genrichDict[wildcards.group])
+    output:
+        "genrich/{group}.narrowPeak"
+    params:
+        bams = lambda wildcards: ",".join(expand(os.path.join(outdir_MACS2 + "/{sample}.short.cleaned.bam"), sample=genrichDict[wildcards.group])),
+        blacklist = "-E {}".format(blacklist_bed) if blacklist_bed else ""
+    conda: CONDA_ATAC_ENV
+    shell: """
+        Genrich -S -t {params.bams} -o {output} -r {params.blacklist} -j -y
         """

--- a/snakePipes/shared/rules/ATAC.snakefile
+++ b/snakePipes/shared/rules/ATAC.snakefile
@@ -119,11 +119,11 @@ rule HMMRATAC_peaks:
 # Should be run once per-group!
 rule Genrich_peaks:
     input:
-        bams=lambda wildcards: expand(os.path.join(outdir_MACS2 + "/{sample}.short.cleaned.bam"), sample=genrichDict[wildcards.group])
+        bams=lambda wildcards: expand(os.path.join(outdir_MACS2, "{sample}.short.cleaned.bam"), sample=genrichDict[wildcards.group])
     output:
         "genrich/{group}.narrowPeak"
     params:
-        bams = lambda wildcards: ",".join(expand(os.path.join(outdir_MACS2 + "/{sample}.short.cleaned.bam"), sample=genrichDict[wildcards.group])),
+        bams = lambda wildcards: ",".join(expand(os.path.join(outdir_MACS2, "{sample}.short.cleaned.bam"), sample=genrichDict[wildcards.group])),
         blacklist = "-E {}".format(blacklist_bed) if blacklist_bed else ""
     conda: CONDA_ATAC_ENV
     shell: """

--- a/snakePipes/shared/rules/ATAC.snakefile
+++ b/snakePipes/shared/rules/ATAC.snakefile
@@ -121,7 +121,7 @@ rule Genrich_peaks:
     input:
         bams=lambda wildcards: expand(os.path.join(outdir_MACS2, "{sample}.short.cleaned.bam"), sample=genrichDict[wildcards.group])
     output:
-        "genrich/{group}.narrowPeak"
+        "Genrich/{group}.narrowPeak"
     params:
         bams = lambda wildcards: ",".join(expand(os.path.join(outdir_MACS2, "{sample}.short.cleaned.bam"), sample=genrichDict[wildcards.group])),
         blacklist = "-E {}".format(blacklist_bed) if blacklist_bed else ""

--- a/snakePipes/shared/rules/CSAW.snakefile
+++ b/snakePipes/shared/rules/CSAW.snakefile
@@ -1,20 +1,30 @@
 sample_name = os.path.splitext(os.path.basename(sampleSheet))[0]
 change_direction = ["UP", "DOWN", "MIXED"]
 
+def getInputPeaks(peakCaller, chip_samples, genrichDict):
+    if peakCaller == "MACS2":
+        return expand("MACS2/{chip_sample}.filtered.BAM_peaks.xls", chip_sample = chip_samples)
+    elif peakCaller == "HMMRATAC":
+        return expand("HMMRATAC/{chip_sample}_peaks.gappedPeak", chip_sample = chip_samples)
+    else:
+        return expand("Genrich/{genrichGroup}.narrowPeak", genrichGroup = genrichDict.keys())
+
+
 ## CSAW for differential binding / allele-specific binding analysis
 rule CSAW:
     input:
-        macs2_output = expand("MACS2/{chip_sample}.filtered.BAM_peaks.xls", chip_sample = chip_samples),
+        peaks = getInputPeaks(peakCaller, chip_samples, genrichDict),
         sampleSheet = sampleSheet,
         insert_size_metrics ="deepTools_qc/bamPEFragmentSize/fragmentSize.metric.tsv" if pairedEnd else []
     output:
-        "CSAW_{}/CSAW.session_info.txt".format(sample_name),
-        "CSAW_{}/DiffBinding_analysis.Rdata".format(sample_name),
-        expand("CSAW_{}".format(sample_name) + "/Filtered.results.{change_dir}.bed", change_dir=change_direction)
+        "CSAW_{}_{}/CSAW.session_info.txt".format(peakCaller, sample_name),
+        "CSAW_{}_{}/DiffBinding_analysis.Rdata".format(peakCaller, sample_name),
+        expand("CSAW_{}_{}".format(peakCaller, sample_name) + "/Filtered.results.{change_dir}.bed", change_dir=change_direction)
     benchmark:
-        "CSAW_{}/.benchmark/CSAW.benchmark".format(sample_name)
+        "CSAW_{}_{}/.benchmark/CSAW.benchmark".format(peakCaller, sample_name)
     params:
-        outdir=os.path.join(outdir, "CSAW_{}".format(sample_name)),
+        outdir=os.path.join(outdir, "CSAW_{}_{}".format(peakCaller, sample_name)),
+        peakCaller=peakCaller,
         fdr = fdr,
         absBestLFC=absBestLFC,
         pairedEnd = pairedEnd,
@@ -25,8 +35,8 @@ rule CSAW:
         yaml_path=lambda wildcards: samples_config if pipeline in 'chip-seq' else "",
         insert_size_metrics=os.path.join(outdir,"deepTools_qc/bamPEFragmentSize/fragmentSize.metric.tsv") if pairedEnd else []
     log: 
-        out = os.path.join(outdir, "CSAW_{}/logs/CSAW.out".format(sample_name)),
-        err = os.path.join(outdir, "CSAW_{}/logs/CSAW.err".format(sample_name))
+        out = os.path.join(outdir, "CSAW_{}_{}/logs/CSAW.out".format(peakCaller, sample_name)),
+        err = os.path.join(outdir, "CSAW_{}_{}/logs/CSAW.err".format(peakCaller, sample_name))
     conda: CONDA_ATAC_ENV
     script: "../rscripts/CSAW.R"
 
@@ -35,16 +45,16 @@ if allele_info == 'FALSE':
     if pipeline in 'chip-seq':
         rule calc_matrix_log2r_CSAW:
             input:
-                csaw_in = "CSAW_{}/CSAW.session_info.txt".format(sample_name),
+                csaw_in = "CSAW_{}_{}/CSAW.session_info.txt".format(peakCaller, sample_name),
                 bigwigs = expand("deepTools_ChIP/bamCompare/{chip_sample}.filtered.log2ratio.over_{control_name}.bw", zip, chip_sample=filtered_dict.keys(), control_name=filtered_dict.values()),
                 sampleSheet = sampleSheet
             output:
-                matrix = "CSAW_{}".format(sample_name)+"/CSAW.{change_dir}.log2r.matrix"
+                matrix = "CSAW_{}_{}".format(peakCaller, sample_name)+"/CSAW.{change_dir}.log2r.matrix"
             params:
-                bed_in = "CSAW_{}".format(sample_name)+"/Filtered.results.{change_dir}.bed"
+                bed_in = "CSAW_{}_{}".format(peakCaller, sample_name)+"/Filtered.results.{change_dir}.bed"
             log:
-                out = os.path.join(outdir, "CSAW_{}".format(sample_name) + "/logs/deeptools_matrix.log2r.{change_dir}.out"),
-                err = os.path.join(outdir, "CSAW_{}".format(sample_name) + "/logs/deeptools_matrix.log2r.{change_dir}.err")
+                out = os.path.join(outdir, "CSAW_{}_{}".format(peakCaller, sample_name) + "/logs/deeptools_matrix.log2r.{change_dir}.out"),
+                err = os.path.join(outdir, "CSAW_{}_{}".format(peakCaller, sample_name) + "/logs/deeptools_matrix.log2r.{change_dir}.err")
             threads: 8
             conda: CONDA_SHARED_ENV
             shell: """
@@ -58,15 +68,15 @@ if allele_info == 'FALSE':
 
         rule plot_heatmap_log2r_CSAW:
             input:
-                matrix = "CSAW_{}".format(sample_name) + "/CSAW.{change_dir}.log2r.matrix"
+                matrix = "CSAW_{}_{}".format(peakCaller, sample_name) + "/CSAW.{change_dir}.log2r.matrix"
             output:
-                image = "CSAW_{}".format(sample_name) + "/CSAW.{change_dir}.log2r.heatmap.png",
-                sorted_regions = "CSAW_{}".format(sample_name) + "/CSAW.{change_dir}.log2r.sortedRegions.bed"
+                image = "CSAW_{}_{}".format(peakCaller, sample_name) + "/CSAW.{change_dir}.log2r.heatmap.png",
+                sorted_regions = "CSAW_{}_{}".format(peakCaller, sample_name) + "/CSAW.{change_dir}.log2r.sortedRegions.bed"
             params:
                 smpl_label=' '.join(filtered_dict.keys())
             log:
-                out = os.path.join(outdir, "CSAW_{}".format(sample_name) + "/logs/deeptools_heatmap.log2r.{change_dir}.out"),
-                err = os.path.join(outdir, "CSAW_{}".format(sample_name) + "/logs/deeptools_heatmap.log2r.{change_dir}.err")
+                out = os.path.join(outdir, "CSAW_{}_{}".format(peakCaller, sample_name) + "/logs/deeptools_heatmap.log2r.{change_dir}.out"),
+                err = os.path.join(outdir, "CSAW_{}_{}".format(peakCaller, sample_name) + "/logs/deeptools_heatmap.log2r.{change_dir}.err")
             conda: CONDA_SHARED_ENV
             shell: """
                 touch {log.out}
@@ -85,16 +95,16 @@ if allele_info == 'FALSE':
 
     rule calc_matrix_cov_CSAW:
         input:
-            csaw_in = "CSAW_{}/CSAW.session_info.txt".format(sample_name),
+            csaw_in = "CSAW_{}_{}/CSAW.session_info.txt".format(peakCaller, sample_name),
             bigwigs = expand("bamCoverage/{chip_sample}.filtered.seq_depth_norm.bw", chip_sample=filtered_dict.keys()),
             sampleSheet = sampleSheet
         output:
-            matrix = "CSAW_{}".format(sample_name) + "/CSAW.{change_dir}.cov.matrix"
+            matrix = "CSAW_{}_{}".format(peakCaller, sample_name) + "/CSAW.{change_dir}.cov.matrix"
         params:
-            bed_in = "CSAW_{}".format(sample_name) + "/Filtered.results.{change_dir}.bed"
+            bed_in = "CSAW_{}_{}".format(peakCaller, sample_name) + "/Filtered.results.{change_dir}.bed"
         log:
-            out = os.path.join(outdir, "CSAW_{}".format(sample_name) + "/logs/deeptools_matrix.cov.{change_dir}.out"),
-            err = os.path.join(outdir, "CSAW_{}".format(sample_name) + "/logs/deeptools_matrix.cov.{change_dir}.err")
+            out = os.path.join(outdir, "CSAW_{}_{}".format(peakCaller, sample_name) + "/logs/deeptools_matrix.cov.{change_dir}.out"),
+            err = os.path.join(outdir, "CSAW_{}_{}".format(peakCaller, sample_name) + "/logs/deeptools_matrix.cov.{change_dir}.err")
         threads: 8
         conda: CONDA_SHARED_ENV
         shell: """
@@ -108,15 +118,15 @@ if allele_info == 'FALSE':
 
     rule plot_heatmap_cov_CSAW:
         input:
-            matrix = "CSAW_{}".format(sample_name) + "/CSAW.{change_dir}.cov.matrix"
+            matrix = "CSAW_{}_{}".format(peakCaller, sample_name) + "/CSAW.{change_dir}.cov.matrix"
         output:
-            image = "CSAW_{}".format(sample_name) + "/CSAW.{change_dir}.cov.heatmap.png",
-            sorted_regions = "CSAW_{}".format(sample_name) + "/CSAW.{change_dir}.cov.sortedRegions.bed"
+            image = "CSAW_{}_{}".format(peakCaller, sample_name) + "/CSAW.{change_dir}.cov.heatmap.png",
+            sorted_regions = "CSAW_{}_{}".format(peakCaller, sample_name) + "/CSAW.{change_dir}.cov.sortedRegions.bed"
         params:
             smpl_label=' '.join(filtered_dict.keys())
         log:
-            out = os.path.join(outdir,"CSAW_{}".format(sample_name) + "/logs/deeptools_heatmap.cov.{change_dir}.out"),
-            err = os.path.join(outdir,"CSAW_{}".format(sample_name) + "/logs/deeptools_heatmap.cov.{change_dir}.err")
+            out = os.path.join(outdir,"CSAW_{}_{}".format(peakCaller, sample_name) + "/logs/deeptools_heatmap.cov.{change_dir}.out"),
+            err = os.path.join(outdir,"CSAW_{}_{}".format(peakCaller, sample_name) + "/logs/deeptools_heatmap.cov.{change_dir}.err")
         conda: CONDA_SHARED_ENV
         shell: """
             touch {log.out}
@@ -134,18 +144,18 @@ if allele_info == 'FALSE':
 
     rule CSAW_report:
         input:
-            csaw_in = "CSAW_{}/CSAW.session_info.txt".format(sample_name),
-            heatmap_in=lambda wildcards: expand("CSAW_{}".format(sample_name) + "/CSAW.{change_dir}.cov.heatmap.png", change_dir=['UP','DOWN']) if pipeline in 'ATAC-seq' else expand("CSAW_{}".format(sample_name) + "/CSAW.{change_dir}.cov.heatmap.png", change_dir=['UP','DOWN']) + expand("CSAW_{}".format(sample_name) + "/CSAW.{change_dir}.log2r.heatmap.png", change_dir=['UP', 'DOWN'])
+            csaw_in = "CSAW_{}_{}/CSAW.session_info.txt".format(peakCaller, sample_name),
+            heatmap_in=lambda wildcards: expand("CSAW_{}_{}".format(peakCaller, sample_name) + "/CSAW.{change_dir}.cov.heatmap.png", change_dir=['UP','DOWN']) if pipeline in 'ATAC-seq' else expand("CSAW_{}_{}".format(peakCaller, sample_name) + "/CSAW.{change_dir}.cov.heatmap.png", change_dir=['UP','DOWN']) + expand("CSAW_{}_{}".format(peakCaller, sample_name) + "/CSAW.{change_dir}.log2r.heatmap.png", change_dir=['UP', 'DOWN'])
         output:
-            outfile="CSAW_{}/CSAW.Stats_report.html".format(sample_name)
+            outfile="CSAW_{}_{}/CSAW.Stats_report.html".format(peakCaller, sample_name)
         params:
             pipeline=pipeline,
             fdr=fdr,
             lfc=absBestLFC,
-            outdir=os.path.join(outdir, "CSAW_{}".format(sample_name)),
+            outdir=os.path.join(outdir, "CSAW_{}_{}".format(peakCaller, sample_name)),
             sampleSheet=sampleSheet
         log:
-           out = os.path.join(outdir, "CSAW_{}/logs/report.out".format(sample_name)),
-           err = os.path.join(outdir, "CSAW_{}/logs/report.err".format(sample_name))
+           out = os.path.join(outdir, "CSAW_{}_{}/logs/report.out".format(peakCaller, sample_name)),
+           err = os.path.join(outdir, "CSAW_{}_{}/logs/report.err".format(peakCaller, sample_name))
         conda: CONDA_ATAC_ENV
         script: "../rscripts/CSAW_report.Rmd"

--- a/snakePipes/shared/rules/ChIP_peak_calling.snakefile
+++ b/snakePipes/shared/rules/ChIP_peak_calling.snakefile
@@ -132,3 +132,21 @@ rule MACS2_peak_qc:
 
 # TODO
 # add joined deepTools plotEnrichment call for all peaks and samples in one plot
+
+# Requires PE data
+# Should be run once per-group!
+rule Genrich_peaks:
+    input:
+        IP=lambda wildcards: expand("filtered_bam/{sample}.filtered.bam", sample=wildcards.sample),
+        control =
+                lambda wildcards: "filtered_bam/"+get_control(wildcards.sample)+".filtered.bam" if get_control(wildcards.sample)
+                else []
+    output:
+        "Genrich/{sample}.narrowPeak"
+    params:
+        control=lambda wildcards: "-c" if get_control(wildcards.sample) else "",
+        blacklist = "-E {}".format(blacklist_bed) if blacklist_bed else ""
+    conda: CONDA_ATAC_ENV
+    shell: """
+        Genrich -S -t {input.IP} {params.control} {input.control} -o {output} -r {params.blacklist} -y
+        """

--- a/snakePipes/shared/rules/envs/atac_seq.yaml
+++ b/snakePipes/shared/rules/envs/atac_seq.yaml
@@ -17,3 +17,5 @@ dependencies:
  - r-statmod = 1.4.30
  - r-yaml
  - r-rmarkdown
+ - hmmratac = 1.2.9
+ - genrich = 0.6

--- a/snakePipes/workflows/ATAC-seq/ATAC-seq
+++ b/snakePipes/workflows/ATAC-seq/ATAC-seq
@@ -24,6 +24,7 @@ def parse_args(defaults={"verbose": False, "configFile": None,
                          "bamExt": "filtered.bam", "fdr": 0.05,
                          "absBestLFC": 1, "UMIDedup": False,
                          "UMIDedupOpts": "", "UMIDedupSep": "_",
+                         "peakCaller": "MACS2",
                          "UMIBarcode": False, "bcPattern": ""}):
 
     """
@@ -41,6 +42,11 @@ def parse_args(defaults={"verbose": False, "configFile": None,
 
     # Workflow options
     optional = parser.add_argument_group('Options')
+    optional.add_argument("--peakCaller",
+                          help="The peak caller to use. The default is %(default)s",
+                          choices=["MACS2", "HMMRATAC", "Genrich"],
+                          default=defaults['peakCaller'])
+
     optional.add_argument("--maxFragmentSize",
                           help="Maximum size of (typically nucleosomal) fragments for inclusion in the analysis (default: '%(default)s')",
                           type=int,

--- a/snakePipes/workflows/ATAC-seq/Snakefile
+++ b/snakePipes/workflows/ATAC-seq/Snakefile
@@ -75,8 +75,8 @@ def run_deepTools_allelic():
 
 def run_CSAW():
     if sampleSheet:
-        file_list=["CSAW_{}/CSAW.session_info.txt".format(sample_name),"Annotation/genes.filtered.symbol","Annotation/genes.filtered.t2g","CSAW_{}/CSAW.Stats_report.html".format(sample_name)]
-        file_list.append([os.path.join("CSAW_{}".format(sample_name), x) for x in list(itertools.chain.from_iterable([expand("CSAW.{change_dir}.cov.matrix",change_dir=change_direction),expand("CSAW.{change_dir}.cov.heatmap.png",change_dir=change_direction)]))])
+        file_list=["CSAW_{}_{}/CSAW.session_info.txt".format(peakCaller, sample_name),"Annotation/genes.filtered.symbol","Annotation/genes.filtered.t2g","CSAW_{}_{}/CSAW.Stats_report.html".format(peakCaller, sample_name)]
+        file_list.append([os.path.join("CSAW_{}_{}".format(peakCaller, sample_name), x) for x in list(itertools.chain.from_iterable([expand("CSAW.{change_dir}.cov.matrix",change_dir=change_direction),expand("CSAW.{change_dir}.cov.heatmap.png",change_dir=change_direction)]))])
         file_list.append([os.path.join("AnnotatedResults_{}".format(sample_name), x) for x in list(itertools.chain.from_iterable([expand("Filtered.results.{change_dir}_withNearestGene.txt",change_dir=change_direction)]))])
         return( file_list )
     else:
@@ -100,15 +100,19 @@ def run_deepTools_qc(fromBAM):
 
 # This needs to be optional
 def run_HMMRATAC():
-    file_list = expand("HMMRATAC/{sample}_peaks.gappedPeak", sample=samples)
+    file_list = []
+    if peakCaller == "HMMRATAC":
+        file_list = expand("HMMRATAC/{sample}_peaks.gappedPeak", sample=samples)
     return (file_list)
 
 
 def run_genrich():
-    file_list = ["genrich/all_samples.narrowPeak"]
-    if sampleSheet:
-        file_list = ["genrich/{}.narrowPeak".format(x) for x in genrichDict.keys()]
-    return (file_list)
+    if peakCaller == "Genrich":
+        file_list = ["Genrich/all_samples.narrowPeak"]
+        if sampleSheet:
+            file_list = ["Genrich/{}.narrowPeak".format(x) for x in genrichDict.keys()]
+        return (file_list)
+    return ([])
 
 
 ### execute before workflow starts #############################################

--- a/snakePipes/workflows/ATAC-seq/Snakefile
+++ b/snakePipes/workflows/ATAC-seq/Snakefile
@@ -98,6 +98,19 @@ def run_deepTools_qc(fromBAM):
     return (file_list)
 
 
+# This needs to be optional
+def run_HMMRATAC():
+    file_list = expand("HMMRATAC/{sample}_peaks.gappedPeak", sample=samples)
+    return (file_list)
+
+
+def run_genrich():
+    file_list = ["genrich/all_samples.narrowPeak"]
+    if sampleSheet:
+        file_list = ["genrich/{}.narrowPeak".format(x) for x in genrichDict.keys()]
+    return (file_list)
+
+
 ### execute before workflow starts #############################################
 ################################################################################
 onstart:
@@ -127,7 +140,7 @@ onstart:
 
     if toolsVersion:
         usedEnvs = [CONDA_SHARED_ENV, CONDA_ATAC_ENV]
-        cf.writeTools(usedEnvs, "ATAC-seq", maindir)
+        cf.writeTools(usedEnvs, workingdir, "ATAC-seq", maindir)
 
 ### main rule ##################################################################
 ################################################################################
@@ -139,6 +152,10 @@ rule all:
         os.path.join(deeptools_ATAC, "plotFingerprint/plotFingerprint.metrics.txt"),
         ## run deeptools-allelic only if dir "allelic_bams" present and non empty
         run_deepTools_allelic(),
+        ## run HMMRATAC
+        run_HMMRATAC(),
+        ## run Genrich, this sets genrich_groups
+        run_genrich(),
         ## run csaw if asked for
         run_CSAW(),
         expand("deepTools_ATAC/bamCompare/{sample}.filtered.bw",sample=samples),

--- a/snakePipes/workflows/ATAC-seq/defaults.yaml
+++ b/snakePipes/workflows/ATAC-seq/defaults.yaml
@@ -30,6 +30,8 @@ sampleSheet:
 # windowSize
 windowSize: 20
 fragmentCountThreshold: 1
+## The peak caller to use
+peakCaller: "MACS2"
 #### Flag to control the pipeline entry point
 ## Bin size of output files in bigWig format
 bwBinSize: 25

--- a/snakePipes/workflows/ATAC-seq/internals.snakefile
+++ b/snakePipes/workflows/ATAC-seq/internals.snakefile
@@ -67,3 +67,6 @@ def filter_dict(sampleSheet):
 
 if sampleSheet:
     filtered_dict = filter_dict(sampleSheet)
+    genrichDict = cf.sampleSheetGroups(sampleSheet)
+else:
+    genrichDict = {"all_samples": samples}

--- a/snakePipes/workflows/ChIP-seq/ChIP-seq
+++ b/snakePipes/workflows/ChIP-seq/ChIP-seq
@@ -21,7 +21,7 @@ def parse_args(defaults={"verbose": False, "configFile": None,
                          "snakemakeOptions": "--use-conda", "tempDir": None,
                          "pairedEnd": True, "fragmentLength":200, "bwBinSize": 25, "qval": 0.001, "sampleSheet": "",
                          "windowSize": 150, "predictChIPDict": None,
-                         "bigWigType": "both", "mfold": "0 50",
+                         "bigWigType": "both", "mfold": "0 50", "peakCaller": "MACS2",
                          "plotFormat": "png","fromBAM": False, "bamExt": ".filtered.bam",
                          "fdr": 0.05, "absBestLFC": 1}):
 
@@ -43,6 +43,11 @@ def parse_args(defaults={"verbose": False, "configFile": None,
 
     # Workflow options
     optional = parser.add_argument_group('Options')
+    optional.add_argument("--peakCaller",
+                          help="The peak caller to use. The default is %(default)s",
+                          choices=["MACS2", "Genrich"],
+                          default=defaults['peakCaller'])
+
     optional.add_argument("--singleEnd",
                           dest="pairedEnd",
                           action="store_false",

--- a/snakePipes/workflows/ChIP-seq/ChIP-seq
+++ b/snakePipes/workflows/ChIP-seq/ChIP-seq
@@ -44,7 +44,7 @@ def parse_args(defaults={"verbose": False, "configFile": None,
     # Workflow options
     optional = parser.add_argument_group('Options')
     optional.add_argument("--peakCaller",
-                          help="The peak caller to use. The default is %(default)s",
+                          help="The peak caller to use. The default is %(default)s and this is only applicable for sharper peaks (broad peaks will always use histoneHMM).",
                           choices=["MACS2", "Genrich"],
                           default=defaults['peakCaller'])
 

--- a/snakePipes/workflows/ChIP-seq/Snakefile
+++ b/snakePipes/workflows/ChIP-seq/Snakefile
@@ -124,6 +124,16 @@ def run_CSAW():
     else:
         return([])
 
+
+def run_genrich():
+    if peakCaller == "Genrich":
+        file_list = ["genrich/all_samples.narrowPeak"]
+        if sampleSheet:
+            file_list = ["genrich/{}.narrowPeak".format(x) for x in genrichDict.keys()]
+        return (file_list)
+    return ([])
+
+
 ### execute before workflow starts #############################################
 ################################################################################
 onstart:
@@ -166,6 +176,7 @@ rule all:
         run_deepTools_ChIP(),
         expand("MACS2/{chip_sample}.filtered.BAM_peaks.xls", chip_sample = chip_samples),
         expand("MACS2/{chip_sample}.filtered.BAM_peaks.qc.txt", chip_sample = chip_samples),
+        run_genrich(),
         # run histoneHMM if allelic_bams are absent (since it gives index error without allele_specific index)
         run_histoneHMM(allele_info),
         ## run deeptools-allelic only if dir "allelic_bams" present and non empty

--- a/snakePipes/workflows/ChIP-seq/Snakefile
+++ b/snakePipes/workflows/ChIP-seq/Snakefile
@@ -156,7 +156,7 @@ onstart:
 
     if toolsVersion:
         usedEnvs = [CONDA_SHARED_ENV, CONDA_CHIPSEQ_ENV]
-        cf.writeTools(usedEnvs, "ChIP-seq", maindir)
+        cf.writeTools(usedEnvs, workingdir, "ChIP-seq", maindir)
 
 ### main rule ##################################################################
 ################################################################################

--- a/snakePipes/workflows/ChIP-seq/Snakefile
+++ b/snakePipes/workflows/ChIP-seq/Snakefile
@@ -32,8 +32,8 @@ if fromBAM:
 # deepTools ChIP
 include: os.path.join(maindir, "shared", "rules", "deepTools_ChIP.snakefile")
 
-# MACS2 and MACS2 peak QC
-include: os.path.join(maindir, "shared", "rules", "MACS2.snakefile")
+# MACS2, MACS2 peak QC, and Genrich
+include: os.path.join(maindir, "shared", "rules", "ChIP_peak_calling.snakefile")
 
 # QC report for all samples
 include: os.path.join(maindir, "shared", "rules", "ChiP-seq_qc_report.snakefile")
@@ -127,9 +127,15 @@ def run_CSAW():
 
 def run_genrich():
     if peakCaller == "Genrich":
-        file_list = ["genrich/all_samples.narrowPeak"]
-        if sampleSheet:
-            file_list = ["genrich/{}.narrowPeak".format(x) for x in genrichDict.keys()]
+        file_list = expand("Genrich/{sample}.narrowPeak", sample=chip_samples)
+        return (file_list)
+    return ([])
+
+
+def run_macs2():
+    if peakCaller == "MACS2":
+        file_list = expand("MACS2/{chip_sample}.filtered.BAM_peaks.xls", chip_sample = chip_samples)
+        file_list.extend(expand("MACS2/{chip_sample}.filtered.BAM_peaks.qc.txt", chip_sample = chip_samples))
         return (file_list)
     return ([])
 
@@ -165,7 +171,7 @@ onstart:
         print("-" * 80, "\n")
 
     if toolsVersion:
-        usedEnvs = [CONDA_SHARED_ENV, CONDA_CHIPSEQ_ENV]
+        usedEnvs = [CONDA_SHARED_ENV, CONDA_CHIPSEQ_ENV, CONDA_ATAC_ENV]
         cf.writeTools(usedEnvs, workingdir, "ChIP-seq", maindir)
 
 ### main rule ##################################################################
@@ -174,8 +180,7 @@ rule all:
     input:
     	run_deepTools_qc(fromBAM),
         run_deepTools_ChIP(),
-        expand("MACS2/{chip_sample}.filtered.BAM_peaks.xls", chip_sample = chip_samples),
-        expand("MACS2/{chip_sample}.filtered.BAM_peaks.qc.txt", chip_sample = chip_samples),
+        run_macs2(),
         run_genrich(),
         # run histoneHMM if allelic_bams are absent (since it gives index error without allele_specific index)
         run_histoneHMM(allele_info),

--- a/snakePipes/workflows/ChIP-seq/defaults.yaml
+++ b/snakePipes/workflows/ChIP-seq/defaults.yaml
@@ -21,6 +21,8 @@ workingdir:
 ## preconfigured target genomes (mm9,mm10,dm3,...) , see /path/to/snakemake_workflows/shared/organisms/
 ## Value can be also path to your own genome config file!
 genome:
+## Which peak caller to use?
+peakCaller: 'MACS2'
 ## paired end data?
 pairedEnd: True
 ## Bin size of output files in bigWig format

--- a/snakePipes/workflows/ChIP-seq/internals.snakefile
+++ b/snakePipes/workflows/ChIP-seq/internals.snakefile
@@ -171,3 +171,6 @@ def filter_dict(sampleSheet,input_dict):
 
 if sampleSheet:
     filtered_dict = filter_dict(sampleSheet,dict(zip(chip_samples_w_ctrl, [ get_control_name(x) for x in chip_samples_w_ctrl ])))
+    genrichDict = cf.sampleSheetGroups(sampleSheet)
+else:
+    genrichDict = {"all_samples": samples}

--- a/snakePipes/workflows/createIndices/Snakefile
+++ b/snakePipes/workflows/createIndices/Snakefile
@@ -121,9 +121,9 @@ onstart:
         print("$HOSTNAME: ",os.getenv('HOSTNAME', ""))
         print("-" * 80, "\n")
 
-        if toolsVersion:
-            usedEnvs = [CONDA_SHARED_ENV, CONDA_CREATE_INDEX_ENV]
-            cf.writeTools(usedEnvs, "createIndices", maindir)
+    if toolsVersion:
+        usedEnvs = [CONDA_SHARED_ENV, CONDA_CREATE_INDEX_ENV]
+        cf.writeTools(usedEnvs, outdir, "createIndices", maindir)
 
 ### main rule ##################################################################
 ################################################################################


### PR DESCRIPTION
This adds Genrich as a peak caller to ChIP-seq and ATAC-seq, which is configurable with the `--peakCaller` option. HMMRATAC is additionally added as an option to the ATAC-seq pipeline.

 - [ ] Document callers in ATAC and ChIP pipelines

HMMRATAC is quite slow whereas Genrich is quicker than MACS2. Genrich generally seems to produce better results on our test data than MACS2 and HMMRATAC, but this may be dataset dependent. Genrich is using replicates in ATAC-seq, but not (yet at least) ChIP-seq. CSAW will look for input from the appropriate peak caller, which has been tested in the ATAC pipeline.

Note that the Genrich command is written to essentially require paired-end data, so that needs to be documented.