### PR TITLE
Dev ksikora2

### DIFF
--- a/docs/content/News.rst
+++ b/docs/content/News.rst
@@ -11,7 +11,7 @@ snakePipes 2.x.y
 * fixed issue with missing input for running the DNA-mapping Snakefile
 * added filtering of empty drops with Dropletutils to scRNAseq mode STARsolo
 * symlinks in the output path are relative 
-
+* 
 
 snakePipes 2.1.1
 ----------------

--- a/docs/content/News.rst
+++ b/docs/content/News.rst
@@ -5,7 +5,6 @@ snakePipes 2.x.y
 ----------------
 * FASTQ1 and FASTQ2 are not localrules anymore due to buggy logging
 * increased BBmap version
-* fixed issue with missing input for running the DNA-mapping Snakefile 
 * added Alevin mode in scRNA workflow
 * included new conda environment using to call AlevinQC.
 * Minor changes to shared FastQC and multiQC rule with regards to scRNA workflow.

--- a/docs/content/News.rst
+++ b/docs/content/News.rst
@@ -9,7 +9,9 @@ snakePipes 2.x.y
 * included new conda environment using to call AlevinQC.
 * Minor changes to shared FastQC and multiQC rule with regards to scRNA workflow.
 * fixed issue with missing input for running the DNA-mapping Snakefile
-* added filtering of empty drops with Dropletutils to scRNAseq mode STARsolo 
+* added filtering of empty drops with Dropletutils to scRNAseq mode STARsolo
+* symlinks in the output path are relative 
+
 
 snakePipes 2.1.1
 ----------------

--- a/docs/content/News.rst
+++ b/docs/content/News.rst
@@ -11,7 +11,7 @@ snakePipes 2.x.y
 * fixed issue with missing input for running the DNA-mapping Snakefile
 * added filtering of empty drops with Dropletutils to scRNAseq mode STARsolo
 * symlinks in the output path are relative 
-* 
+* bumped STAR version to 2.7.4a in scRNAseq, noncoding-RNA-seq and mRNA-seq workflows
 
 snakePipes 2.1.1
 ----------------

--- a/snakePipes/shared/rules/FASTQ.snakefile
+++ b/snakePipes/shared/rules/FASTQ.snakefile
@@ -1,21 +1,20 @@
-import os
 rule origFASTQ1:
       input:
           indir+"/{sample}"+reads[0]+ext
       output:
           "originalFASTQ/{sample}"+reads[0]+".fastq.gz"
-      run:
-        if not os.path.exists(os.path.join(outdir,output[0])):
-            os.symlink(input[0],output[0])
+      shell: """
+                ln -s ../{input[0]} {output[0]}
+          """
 
 rule origFASTQ2:
       input:
           indir+"/{sample}"+reads[1]+ext
       output:
           "originalFASTQ/{sample}"+reads[1]+".fastq.gz"
-      run:
-        if not os.path.exists(os.path.join(outdir,output[0])):
-            os.symlink(input[0],output[0])
+      shell: """
+                ln -s ../{input[0]} {output[0]}
+          """
 
 if downsample:
     if pairedEnd:

--- a/snakePipes/shared/rules/FASTQ.snakefile
+++ b/snakePipes/shared/rules/FASTQ.snakefile
@@ -6,7 +6,7 @@ rule origFASTQ1:
           "originalFASTQ/{sample}"+reads[0]+".fastq.gz"
       run:
         if not os.path.exists(os.path.join(outdir,output[0])):
-            os.symlink(os.path.join(outdir,input[0]),os.path.join(outdir,output[0]))
+            os.symlink(input[0],output[0])
 
 rule origFASTQ2:
       input:
@@ -15,7 +15,7 @@ rule origFASTQ2:
           "originalFASTQ/{sample}"+reads[1]+".fastq.gz"
       run:
         if not os.path.exists(os.path.join(outdir,output[0])):
-            os.symlink(os.path.join(outdir,input[0]),os.path.join(outdir,output[0]))
+            os.symlink(input[0],output[0])
 
 if downsample:
     if pairedEnd:

--- a/snakePipes/shared/rules/FASTQ.snakefile
+++ b/snakePipes/shared/rules/FASTQ.snakefile
@@ -4,7 +4,7 @@ rule origFASTQ1:
       output:
           "originalFASTQ/{sample}"+reads[0]+".fastq.gz"
       shell: """
-                ln -s ../{input[0]} {output[0]}
+                ln -s {input} {output}
           """
 
 rule origFASTQ2:
@@ -13,7 +13,7 @@ rule origFASTQ2:
       output:
           "originalFASTQ/{sample}"+reads[1]+".fastq.gz"
       shell: """
-                ln -s ../{input[0]} {output[0]}
+                ln -s {input} {output}
           """
 
 if downsample:

--- a/snakePipes/shared/rules/LinkBam.snakefile
+++ b/snakePipes/shared/rules/LinkBam.snakefile
@@ -31,10 +31,10 @@ if not pipeline=="noncoding-rna-seq":
             output:
                 bam_out = "filtered_bam/{sample}.filtered.bam",
                 bai_out = "filtered_bam/{sample}.filtered.bam.bai",
-            run:
-                if not os.path.exists(os.path.join(outdir,output.bam_out)):
-                    os.symlink(input.bam,output.bam_out)
-                    os.symlink(input.bai,output.bai_out)
+            shell: """
+                ln -s ../{input.bam} {output.bam_out};
+                ln -s ../{input.bai} {output.bai_out}
+            """
 
 
     rule sambamba_flagstat:

--- a/snakePipes/shared/rules/LinkBam.snakefile
+++ b/snakePipes/shared/rules/LinkBam.snakefile
@@ -33,8 +33,8 @@ if not pipeline=="noncoding-rna-seq":
                 bai_out = "filtered_bam/{sample}.filtered.bam.bai",
             run:
                 if not os.path.exists(os.path.join(outdir,output.bam_out)):
-                    os.symlink(os.path.join(outdir,input.bam),os.path.join(outdir,output.bam_out))
-                    os.symlink(os.path.join(outdir,input.bai),os.path.join(outdir,output.bai_out))
+                    os.symlink(input.bam,output.bam_out)
+                    os.symlink(input.bai,output.bai_out)
 
 
     rule sambamba_flagstat:

--- a/snakePipes/shared/rules/Qualimap_bamqc.snakefile
+++ b/snakePipes/shared/rules/Qualimap_bamqc.snakefile
@@ -36,7 +36,7 @@ rule Qualimap_bamqc_symlink_txt:
         "Qualimap_qc/{sample}.filtered.bamqc_results.txt"
     run:
         if not os.path.exists(os.path.join(outdir,output)):
-            os.symlink(os.path.join(outdir,input),os.path.join(outdir,output))
+            os.symlink(input,output)
 
 
 rule Qualimap_bamqc_symlink_html:
@@ -46,4 +46,4 @@ rule Qualimap_bamqc_symlink_html:
         "Qualimap_qc/{sample}.filtered.bamqc_report.html"
     run:
         if not os.path.exists(os.path.join(outdir,output)):
-            os.symlink(os.path.join(outdir,input),os.path.join(outdir,output))
+            os.symlink(input,output)

--- a/snakePipes/shared/rules/Qualimap_bamqc.snakefile
+++ b/snakePipes/shared/rules/Qualimap_bamqc.snakefile
@@ -1,5 +1,4 @@
 ### Qualimap bamqc #############################################################
-import os
 
 rule Qualimap_bamqc:
     input:
@@ -34,9 +33,9 @@ rule Qualimap_bamqc_symlink_txt:
         "Qualimap_qc/{sample}.filtered/genome_results.txt"
     output:
         "Qualimap_qc/{sample}.filtered.bamqc_results.txt"
-    run:
-        if not os.path.exists(os.path.join(outdir,output)):
-            os.symlink(input,output)
+    shell: """
+         ln -s ../{input} {output}
+            """
 
 
 rule Qualimap_bamqc_symlink_html:
@@ -44,6 +43,6 @@ rule Qualimap_bamqc_symlink_html:
         "Qualimap_qc/{sample}.filtered/qualimapReport.html"
     output:
         "Qualimap_qc/{sample}.filtered.bamqc_report.html"
-    run:
-        if not os.path.exists(os.path.join(outdir,output)):
-            os.symlink(input,output)
+    shell: """
+         ln -s ../{input} {output}
+            """

--- a/snakePipes/shared/rules/SNPsplit.snakefile
+++ b/snakePipes/shared/rules/SNPsplit.snakefile
@@ -16,6 +16,7 @@ if aligner == "Bowtie2":
         shell:
             "SNPsplit {params.pairedEnd}"
             " -o {params.outdir} --snp_file {input.snp} {input.bam} 2> {log}"
+
 elif aligner == "STAR":
     rule snp_split:
         input:

--- a/snakePipes/shared/rules/Salmon.snakefile
+++ b/snakePipes/shared/rules/Salmon.snakefile
@@ -1,5 +1,4 @@
 ## Salmon Index
-import os
 
 rule SalmonIndex:
     input:
@@ -92,11 +91,9 @@ rule Salmon_symlinks:
         quant = "Salmon/{sample}/quant.sf"
     output:
         quant = "Salmon/{sample}.quant.sf"
-    params:
-        quant = "{sample}/quant.sf"
-    run:
-        if not os.path.exists(os.path.join(outdir,output.quant)):
-            os.symlink(input.quant,output.quant)
+    shell: """
+         ln -s ../{input.quant} {output.quant}
+            """
 
 
 rule Salmon_TPM:

--- a/snakePipes/shared/rules/Salmon.snakefile
+++ b/snakePipes/shared/rules/Salmon.snakefile
@@ -96,7 +96,7 @@ rule Salmon_symlinks:
         quant = "{sample}/quant.sf"
     run:
         if not os.path.exists(os.path.join(outdir,output.quant)):
-            os.symlink(os.path.join(outdir,input.quant),os.path.join(outdir,output.quant))
+            os.symlink(input.quant,output.quant)
 
 
 rule Salmon_TPM:

--- a/snakePipes/shared/rules/WGBS.snakefile
+++ b/snakePipes/shared/rules/WGBS.snakefile
@@ -122,10 +122,10 @@ if not skipBamQC:
         output:
             bam = "filtered_bam/{sample}.filtered.bam",
             bai = "filtered_bam/{sample}.filtered.bam.bai"
-        run:
-            if not os.path.exists(os.path.join(outdir,output.bam)):
-                os.symlink(input.bam,output.bam)
-                os.symlink(input.bai,output.bai)
+        shell: """
+            ln -s ../{input.bam} {output.bam}
+            ln -s ../{input.bai} {ouput.bai}
+        """
 
 
 rule getRandomCpGs:

--- a/snakePipes/shared/rules/WGBS.snakefile
+++ b/snakePipes/shared/rules/WGBS.snakefile
@@ -41,6 +41,7 @@ if pairedEnd and not fromBAM:
 	        samtools sort -T "$MYTEMP"/{wildcards.sample} -m 3G -@ 4 -o "{output.sbam}" 2>> {log.err}
             rm -rf "$MYTEMP"
             """
+
 elif not pairedEnd and not fromBAM:
     rule bwameth:
         input:
@@ -123,8 +124,8 @@ if not skipBamQC:
             bai = "filtered_bam/{sample}.filtered.bam.bai"
         run:
             if not os.path.exists(os.path.join(outdir,output.bam)):
-                os.symlink(os.path.join(outdir,input.bam),os.path.join(outdir,output.bam))
-                os.symlink(os.path.join(outdir,input.bai),os.path.join(outdir,output.bai))
+                os.symlink(input.bam,output.bam)
+                os.symlink(input.bai,output.bai)
 
 
 rule getRandomCpGs:

--- a/snakePipes/shared/rules/WGBS.snakefile
+++ b/snakePipes/shared/rules/WGBS.snakefile
@@ -124,7 +124,7 @@ if not skipBamQC:
             bai = "filtered_bam/{sample}.filtered.bam.bai"
         shell: """
             ln -s ../{input.bam} {output.bam}
-            ln -s ../{input.bai} {ouput.bai}
+            ln -s ../{input.bai} {output.bai}
         """
 
 

--- a/snakePipes/shared/rules/bam_filtering.snakefile
+++ b/snakePipes/shared/rules/bam_filtering.snakefile
@@ -1,5 +1,4 @@
 ### samtools_filter ############################################################
-import os
 
 # When modifying the rule samtools_filter, double-check whether the function
 # update_filter() has to be modified too
@@ -12,7 +11,7 @@ rule samtools_filter:
     output:
         bam = temp("filtered_bam/{sample}.filtered.tmp.bam")
     params:
-        shell = lambda wildcards,input,output: "samtools view -@ {} -b {} -o {} {} ".format(str(8 if not local else 2), bam_filter_string,output.bam,input[0]) if bam_filter_string.strip() !="" else "ln -s {} {}".format(input[0],output.bam) 
+        shell = lambda wildcards,input,output: "samtools view -@ {} -b {} -o {} {} ".format(str(8 if not local else 2), bam_filter_string,output.bam,input[0]) if bam_filter_string.strip() !="" else "ln -s ../{} {}".format(input[0],output.bam) 
     log:
         out = "filtered_bam/logs/samtools_filter.{sample}.out",
         err = "filtered_bam/logs/samtools_filter.{sample}.err"

--- a/snakePipes/shared/rules/bam_filtering.snakefile
+++ b/snakePipes/shared/rules/bam_filtering.snakefile
@@ -12,7 +12,7 @@ rule samtools_filter:
     output:
         bam = temp("filtered_bam/{sample}.filtered.tmp.bam")
     params:
-        shell = lambda wildcards,input,output: "samtools view -@ {} -b {} -o {} {} ".format(str(8 if not local else 2), bam_filter_string,output.bam,input[0]) if bam_filter_string.strip() !="" else "ln -s {} {}".format(os.path.join(outdir,input[0]),os.path.join(outdir,"filtered_bam",wildcards.sample+".filtered.tmp.bam")) 
+        shell = lambda wildcards,input,output: "samtools view -@ {} -b {} -o {} {} ".format(str(8 if not local else 2), bam_filter_string,output.bam,input[0]) if bam_filter_string.strip() !="" else "ln -s {} {}".format(input[0],output.bam) 
     log:
         out = "filtered_bam/logs/samtools_filter.{sample}.out",
         err = "filtered_bam/logs/samtools_filter.{sample}.err"

--- a/snakePipes/shared/rules/createIndices.snakefile
+++ b/snakePipes/shared/rules/createIndices.snakefile
@@ -185,7 +185,7 @@ rule starIndex:
     threads: 10
     shell: """
         STAR --runThreadN {threads} --runMode genomeGenerate --genomeDir {params.basedir} --genomeFastaFiles {input} 2> {log}
-        if [[ -w Log.out ]]; rm -v Log.out; elif [[ -w {params.basedir}/Log.out ]]; rm -v {params.basedir}/Log.out
+        if [[ -w Log.out ]]; then rm -v Log.out; elif [[ -w {params.basedir}/Log.out ]]; then rm -v {params.basedir}/Log.out; fi
         """
 
 

--- a/snakePipes/shared/rules/createIndices.snakefile
+++ b/snakePipes/shared/rules/createIndices.snakefile
@@ -185,7 +185,7 @@ rule starIndex:
     threads: 10
     shell: """
         STAR --runThreadN {threads} --runMode genomeGenerate --genomeDir {params.basedir} --genomeFastaFiles {input} 2> {log}
-        rm Log.out
+        if [[ -w Log.out ]]; rm -v Log.out; elif [[ -w {params.basedir}/Log.out ]]; rm -v {params.basedir}/Log.out
         """
 
 

--- a/snakePipes/shared/rules/envs/createIndices.yaml
+++ b/snakePipes/shared/rules/envs/createIndices.yaml
@@ -8,6 +8,6 @@ dependencies:
  - ucsc-genepredtobed
  - bowtie2 = 2.3.5.1
  - hisat2 = 2.1.0
- - star = 2.7.3a
+ - star = 2.7.4a
  - bwa = 0.7.17
  - bwameth = 0.2.2

--- a/snakePipes/shared/rules/envs/dna_mapping.yaml
+++ b/snakePipes/shared/rules/envs/dna_mapping.yaml
@@ -5,3 +5,4 @@ channels:
 dependencies:
  - bowtie2 = 2.3.5.1
  - qualimap = 2.2.2d
+ - samtools = 1.10 ###DON'T TOUCH THIS!!!!

--- a/snakePipes/shared/rules/envs/rna_seq.yaml
+++ b/snakePipes/shared/rules/envs/rna_seq.yaml
@@ -7,7 +7,7 @@ dependencies:
  - samtools = 1.10
  - subread = 2.0.0
  - hisat2 = 2.1.0
- - star = 2.7.3a
+ - star = 2.7.4a
  - salmon = 1.1.0
  - r-base = 3.6.2
  - r-wasabi = 1.0.1

--- a/snakePipes/shared/rules/envs/sc_rna_seq.yaml
+++ b/snakePipes/shared/rules/envs/sc_rna_seq.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
  - umi_tools = 1.0.1
  - samtools = 1.10
- - star = 2.7.3a
+ - star = 2.7.4a
  - r-base = 3.5.1
  - r-stringr = 1.4.0
  - bioconductor-monocle = 2.10.0

--- a/snakePipes/shared/rules/preprocessing.snakefile
+++ b/snakePipes/shared/rules/preprocessing.snakefile
@@ -130,7 +130,7 @@ else:
                 r2="deduplicatedFASTQ/{sample}" + reads[1] + ext
             run:
                 if not os.path.exists(os.path.join(outdir,output.r1)):
-                    os.symlink(os.path.join(outdir,input.r1),os.path.join(outdir,output.r1))
+                    os.symlink(input.r1,output.r1)
                 if not os.path.exists(os.path.join(outdir,output.r2)):
                     os.symlink(os.path.join(outdir,input.r2),os.path.join(outdir,output.r2))
     else:
@@ -141,7 +141,7 @@ else:
                 r1="deduplicatedFASTQ/{sample}" + reads[0] + ext
             run:
                 if not os.path.exists(os.path.join(outdir,output.r1)):
-                    os.symlink(os.path.join(outdir,input.r1),os.path.join(outdir,output.r1))
+                    os.symlink(input.r1,output.r1)
 
 rule splitFastq2YAML:
     input:

--- a/snakePipes/shared/rules/preprocessing.snakefile
+++ b/snakePipes/shared/rules/preprocessing.snakefile
@@ -128,20 +128,19 @@ else:
             output:
                 r1="deduplicatedFASTQ/{sample}" + reads[0] + ext,
                 r2="deduplicatedFASTQ/{sample}" + reads[1] + ext
-            run:
-                if not os.path.exists(os.path.join(outdir,output.r1)):
-                    os.symlink(input.r1,output.r1)
-                if not os.path.exists(os.path.join(outdir,output.r2)):
-                    os.symlink(os.path.join(outdir,input.r2),os.path.join(outdir,output.r2))
+            shell: """
+                ln -s ../{input.r1} {output.r1};
+                ln -s ../{input.r2} {output.r2}
+            """
     else:
         rule clumpify:
             input:
                 r1="mergedFASTQ/{sample}" + reads[0] + ext
             output:
                 r1="deduplicatedFASTQ/{sample}" + reads[0] + ext
-            run:
-                if not os.path.exists(os.path.join(outdir,output.r1)):
-                    os.symlink(input.r1,output.r1)
+            shell: """
+                ln -s ../{input.r1} {output.r1}
+            """
 
 rule splitFastq2YAML:
     input:

--- a/snakePipes/shared/rules/sambamba.snakefile
+++ b/snakePipes/shared/rules/sambamba.snakefile
@@ -23,6 +23,7 @@ rule sambamba_markdup:
            sambamba markdup -t {threads} --sort-buffer-size=6000 --overflow-list-size 600000 --tmpdir $MYTEMP {input} {output} 2> {log.err} > {log.out}
            rm -rf "$MYTEMP"
            """
+
 ## get statistics
 rule sambamba_flagstat_sorted:
        input:

--- a/snakePipes/shared/rules/sambamba.snakefile
+++ b/snakePipes/shared/rules/sambamba.snakefile
@@ -1,5 +1,4 @@
 ##sambamba is used for marking up duplications
-import os
 
 ## see Bowtie2.snakefile or RNA_mapping.snakefile for input
 ## takes the input from RNA mapping or DNA mapping snakefile

--- a/snakePipes/shared/rules/scRNAseq_Alevin.snakefile
+++ b/snakePipes/shared/rules/scRNAseq_Alevin.snakefile
@@ -33,6 +33,7 @@ rule SalmonAlevin:
         shell:"""
             salmon alevin -l {params.libtype} -1 {input.R1} -2 {input.R2} {params.protocol} -i Salmon/SalmonIndex -p {threads} -o {params.outdir} --tgMap {params.tgMap} --dumpFeatures --dumpMtx --numCellBootstraps 100 > {log.out} 2> {log.err}
             """
+
 rule AlevinQC:
         input:
             indum = "Alevin/{sample}/alevin/quants_mat.gz"

--- a/snakePipes/shared/rules/scRNAseq_STARsolo.snakefile
+++ b/snakePipes/shared/rules/scRNAseq_STARsolo.snakefile
@@ -63,7 +63,7 @@ rule STARsolo:
 	    --soloStrand Forward\
 	    --soloUMIdedup Exact 2> {log}
 
-        ln -s {params.prefix}Aligned.sortedByCoord.out.bam {output.bam} 2>> {log}
+        ln -s ../{params.prefix}Aligned.sortedByCoord.out.bam {output.bam} 2>> {log}
  
         rm -rf $MYTEMP
          """

--- a/snakePipes/shared/rules/scRNAseq_STARsolo.snakefile
+++ b/snakePipes/shared/rules/scRNAseq_STARsolo.snakefile
@@ -63,7 +63,7 @@ rule STARsolo:
 	    --soloStrand Forward\
 	    --soloUMIdedup Exact 2> {log}
 
-        ln -s {params.outdir}/{params.prefix}Aligned.sortedByCoord.out.bam {params.outdir}/{output.bam} 2>> {log}
+        ln -s {params.prefix}Aligned.sortedByCoord.out.bam {output.bam} 2>> {log}
  
         rm -rf $MYTEMP
          """

--- a/snakePipes/shared/rules/umi_tools.snakefile
+++ b/snakePipes/shared/rules/umi_tools.snakefile
@@ -1,5 +1,5 @@
 ##umi_tools###############
-import os
+#import os
 
 if UMIBarcode:
     if pairedEnd:
@@ -46,9 +46,13 @@ else:
               "originalFASTQ/downsample_{sample}"+reads[0]+".fastq.gz" if downsample else "originalFASTQ/{sample}"+reads[0]+".fastq.gz"
           output:
               "FASTQ/{sample}"+reads[0]+".fastq.gz"
-          run:
-            if not os.path.exists(os.path.join(outdir,output[0])):
-                os.symlink(input[0],output[0])
+          shell: """
+                ln -s ../{input[0]} {output[0]}
+          """
+
+
+#            if not os.path.exists(os.path.join(outdir,output[0])):
+#                os.symlink(input[0],output[0])
 
     rule FASTQ2:
           input:

--- a/snakePipes/shared/rules/umi_tools.snakefile
+++ b/snakePipes/shared/rules/umi_tools.snakefile
@@ -1,5 +1,4 @@
 ##umi_tools###############
-#import os
 
 if UMIBarcode:
     if pairedEnd:
@@ -47,21 +46,17 @@ else:
           output:
               "FASTQ/{sample}"+reads[0]+".fastq.gz"
           shell: """
-                ln -s ../{input[0]} {output[0]}
+                ln -s ../{input} {output}
           """
-
-
-#            if not os.path.exists(os.path.join(outdir,output[0])):
-#                os.symlink(input[0],output[0])
 
     rule FASTQ2:
           input:
               "originalFASTQ/downsample_{sample}"+reads[1]+".fastq.gz" if downsample else "originalFASTQ/{sample}"+reads[1]+".fastq.gz"
           output:
               "FASTQ/{sample}"+reads[1]+".fastq.gz"
-          run:
-            if not os.path.exists(os.path.join(outdir,output[0])):
-                os.symlink(input[0],output[0])
+          shell: """
+                ln -s ../{input} {output}
+          """
 
 #If DNA-mapping:
 if UMIDedup:
@@ -102,9 +97,9 @@ else:
                 bamfile = aligner+"/{sample}.bam"
             output:
                 bamfile = "filtered_bam/{sample}.filtered.bam"
-            run:
-                if not os.path.exists(os.path.join(outdir,output[0])):
-                    os.symlink(input[0],output[0])
+            shell: """
+                ln -s ../{input} {output}
+          """
 
 if not aligner=="bwameth":
     rule samtools_index_filtered:

--- a/snakePipes/shared/rules/umi_tools.snakefile
+++ b/snakePipes/shared/rules/umi_tools.snakefile
@@ -48,7 +48,7 @@ else:
               "FASTQ/{sample}"+reads[0]+".fastq.gz"
           run:
             if not os.path.exists(os.path.join(outdir,output[0])):
-                os.symlink(os.path.join(outdir,input[0]),os.path.join(outdir,output[0]))
+                os.symlink(input[0],output[0])
 
     rule FASTQ2:
           input:
@@ -57,7 +57,7 @@ else:
               "FASTQ/{sample}"+reads[1]+".fastq.gz"
           run:
             if not os.path.exists(os.path.join(outdir,output[0])):
-                os.symlink(os.path.join(outdir,input[0]),os.path.join(outdir,output[0]))
+                os.symlink(input[0],output[0])
 
 #If DNA-mapping:
 if UMIDedup:
@@ -91,6 +91,7 @@ else:
             shell: """
                    mv {input.bamfile} {output.bamfile}
                    """
+
     elif not aligner=="bwameth" :
         rule filter_reads:
             input:
@@ -99,7 +100,7 @@ else:
                 bamfile = "filtered_bam/{sample}.filtered.bam"
             run:
                 if not os.path.exists(os.path.join(outdir,output[0])):
-                    os.symlink(os.path.join(outdir,input[0]),os.path.join(outdir,output[0]))
+                    os.symlink(input[0],output[0])
 
 if not aligner=="bwameth":
     rule samtools_index_filtered:


### PR DESCRIPTION
- symlinks between subfolders of the working directory are now relative, without using `-r` in ln.
- added samtools back to DNA mapping env as Bowtie2 output is piped through it
- bumped STAR version to 2.7.4a in 3 workflows
- minor fix in createIndices to adjust for the new location of the STAR log file
- DNA-mapping, ChIPseq, mRNAseq, WGBS and scRNAseq STARsolo tested