### PR TITLE
Fixed --fragmentLength argument in computeGCBias rule

### DIFF
--- a/snakePipes/shared/rules/deepTools_qc.snakefile
+++ b/snakePipes/shared/rules/deepTools_qc.snakefile
@@ -188,7 +188,7 @@ rule computeGCBias:
         genome_size = int(genome_size),
         genome_2bit = genome_2bit,
         blacklist = "--blackListFileName {}".format(blacklist_bed) if blacklist_bed else "",
-        median_fragment_length = "" if pairedEnd else "-fragmentLength {}".format(fragmentLength),
+        median_fragment_length = "" if pairedEnd else "--fragmentLength {}".format(fragmentLength),
         sampleSize = downsample if downsample and downsample < 10000000 else 10000000
     log:
         out = "deepTools_qc/logs/computeGCBias.{sample}.filtered.out",


### PR DESCRIPTION
Because single-end experiments requires this option to be set, the argument only had one hyphen instead of two.