### PR TITLE
zenodo links for indices

### DIFF
--- a/docs/content/setting_up.rst
+++ b/docs/content/setting_up.rst
@@ -192,10 +192,10 @@ Download premade indices
 
 For the sake of convenience, we provide premade indices for the following organisms:
 
- - `Human (GRCh38, Gencode release 29) <https://zenodo.org/record/2650763>`__
- - `Mouse (GRCm38/mm10, Gencode release m19) <https://zenodo.org/record/4020455>`__
- - `Mouse (GRCm37/mm9, Gencode release 1) <https://zenodo.org/record/2650849>`__
- - `Fruit fly (dm6, Ensembl release 94) <https://zenodo.org/record/2650762>`__
+ - `Human (GRCh38, Gencode release 29) <https://zenodo.org/record/4471116>`__
+ - `Mouse (GRCm38/mm10, Gencode release m19) <https://zenodo.org/record/4468065>`__
+ - `Mouse (GRCm37/mm9, Gencode release 1) <https://zenodo.org/record/4478284>`__
+ - `Fruit fly (dm6, Ensembl release 94) <https://zenodo.org/record/4478414>`__
 
 To use these, simply download and extract them. You will then need to modify the provided YAML file to indicate exactly where the indices are located (i.e., replace ``/data/processing/ryan`` with whatever is appropriate).
 


### PR DESCRIPTION
Updated zenodo links to point to premade indices including STAR index compatible with 2.7.4a and later versions.