### PR TITLE
Always check for >0 rows with regard to using heatmap_data

### DIFF
--- a/snakePipes/shared/rscripts/DESeq2Report.Rmd
+++ b/snakePipes/shared/rscripts/DESeq2Report.Rmd
@@ -157,7 +157,7 @@ Most of the exploration below is based on the annotated DESeq2 output file gener
     ## Extract data for heatmap
     # order by fold change (by abs foldch if only few top genes requested)
     #print("Preparing data: heatmap")
-    if (nrow(df.filt) > 1) {
+    if (nrow(df.filt) > 0) {
         d <- data.frame(id = rownames(df.filt), padj = df.filt$padj)
         if (length(rownames(d)) < heatmap_topN ) {
             heatmap_topN <- nrow(d)
@@ -398,7 +398,7 @@ This plot shows a heatmap of DESeq2-normlized counts for the **top 20** differen
 
 ```{r 'heatmap2', fig.show=TRUE}
 # 7.1 Heatmap topN genes z-score
-if (nrow(df.filt) > 1) {
+if (nrow(df.filt) > 0) {
     pheatmap(heatmap_data,
              cluster_rows = TRUE,
              clustering_method = "average",


### PR DESCRIPTION
In case there is only one single DEG gene, the variable heatmap_data is NOT being created, however later used because in **line 382**, the check was for >0 instead for >1. This then leads to the well understandable error that the object heatmap_data does not exist.

I changed all related checks to >0, because I don't see a reason why >1 would make sense, but of course both are possible. Just not both at the same time as is the case for the moment. 