### PR TITLE
Fix docs build

### DIFF
--- a/snakePipes/common_functions.py
+++ b/snakePipes/common_functions.py
@@ -827,5 +827,5 @@ def copySampleSheet(sampleSheet, wdir):
         try:
             shutil.copy(sampleSheet, os.path.join(wdir, bname))
         except Exception as err:
-            print(f"Unexpected {err=}, {type(err)=}")
+            print("Unexpected error:\n{}".format(err))
             raise


### PR DESCRIPTION
see: https://readthedocs.org/projects/snakepipes/builds/21581371/

```
  File "../snakePipes/workflows/ATAC-seq/ATAC-seq", line 14, in <module>
    import snakePipes.common_functions as cf
  File "<fstring>", line 1
    (err=)
        ^
SyntaxError: invalid syntax
```