### PR TITLE
include the workflow in run.done file

### DIFF
--- a/snakePipes/common_functions.py
+++ b/snakePipes/common_functions.py
@@ -723,7 +723,7 @@ def runAndCleanup(args, cmd, logfile_name):
         sys.exit(p.returncode)
     else:
         Path(
-            os.path.join(args.outdir, "snakePipes.done")
+            os.path.join(args.outdir, "{}_snakePipes.done".format(logfile_name.split('_')[0]))
         ).touch()
         if os.path.exists(os.path.join(args.outdir, ".snakemake")):
             shutil.rmtree(os.path.join(args.outdir, ".snakemake"), ignore_errors=True)


### PR DESCRIPTION
Minor change to have workflow inside of the snakePipes.done flag (important to discriminate DNA / ChIP, or DNA / ATAC when stitching workflows).