### PR TITLE
ruamel - fix ChIPtests

### DIFF
--- a/tests/test_jobcounts.py
+++ b/tests/test_jobcounts.py
@@ -504,6 +504,20 @@ class TestChIPseq:
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
         assert parseSpOut(_p) == 59
+    def test_nosamplesheet(self, ifs):
+        ci = [
+            "ChIP-seq",
+            '-d',
+            ifs / 'bam_input',
+            '--snakemakeOptions',
+            SMKOPTS,
+            ifs / 'org.yaml',
+            ifs / 'chipdict.yaml'
+        ]
+        print(' '.join([str(i) for i in ci]))
+        _p = sp.run(ci, capture_output=True, text=True)
+        assert _p.returncode == 0
+        assert parseSpOut(_p) == 37
     def test_broad(self, ifs):
         ci = [
             "ChIP-seq",
@@ -555,7 +569,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 71
+        assert parseSpOut(_p) == 70
     def test_seacr_spikein(self, ifs):
         ci = [
             "ChIP-seq",

--- a/tests/test_jobcounts.py
+++ b/tests/test_jobcounts.py
@@ -1,8 +1,7 @@
 import subprocess as sp
 import pytest
-import yaml
+from ruamel.yaml import YAML
 import pandas as pd
-
 
 GENOME = "ftp://ftp.ensembl.org/pub/release-93/fasta/mus_musculus/dna/Mus_musculus.GRCm38.dna_sm.primary_assembly.fa.gz"
 GTF = "ftp://ftp.ensembl.org/pub/release-93/gtf/mus_musculus/Mus_musculus.GRCm38.93.gtf.gz"
@@ -26,6 +25,10 @@ def parseSpOut(_s) -> int:
         return (0)
 
 def createTestData(fp, samples=9) -> None:
+    yaml = YAML()
+    yaml.boolean_representation = ['False', 'True']
+    #yaml.default_flow_style = False
+    #yaml.default_style = None
     # single end folder
     (fp / 'SE').mkdir()
     # paired end folder
@@ -125,7 +128,7 @@ def createTestData(fp, samples=9) -> None:
         'rmsk_file': (fp / 'ref' / 'rmsk.txt').as_posix()
     }
     with open(fp / 'org.yaml', 'w') as of:
-        yaml.dump(orgyaml, of, default_flow_style=False)
+        yaml.dump(orgyaml, of)
 
     # create test samplesheet
     pd.DataFrame(
@@ -153,54 +156,54 @@ def createTestData(fp, samples=9) -> None:
     # ChIP sample_config
     chip_dict ={
         'chip_dict': {
-            'sample1': {'control': 'sample7', 'broad': 'False'},
-            'sample2': {'control': 'sample7', 'broad': 'False'},
-            'sample3': {'control': 'sample8', 'broad': 'False'},
-            'sample4': {'control': 'sample8', 'broad': 'False'},
-            'sample5': {'control': 'sample9', 'broad': 'False'},
-            'sample6': {'control': 'sample9', 'broad': 'False'}
+            'sample1': {'control': 'sample7', 'broad': False},
+            'sample2': {'control': 'sample7', 'broad': False},
+            'sample3': {'control': 'sample8', 'broad': False},
+            'sample4': {'control': 'sample8', 'broad': False},
+            'sample5': {'control': 'sample9', 'broad': False},
+            'sample6': {'control': 'sample9', 'broad': False}
         }
     }
     with open(fp / 'chipdict.yaml', 'w') as f:
-        yaml.dump(chip_dict, f, default_flow_style=False, default_style=None)
+        yaml.dump(chip_dict, f)
 
     chip_dict_broad ={
         'chip_dict': {
-            'sample1': {'control': 'sample7', 'broad': 'True'},
-            'sample2': {'control': 'sample7', 'broad': 'True'},
-            'sample3': {'control': 'sample8', 'broad': 'True'},
-            'sample4': {'control': 'sample8', 'broad': 'True'},
-            'sample5': {'control': 'sample9', 'broad': 'True'},
-            'sample6': {'control': 'sample9', 'broad': 'True'}
+            'sample1': {'control': 'sample7', 'broad': True},
+            'sample2': {'control': 'sample7', 'broad': True},
+            'sample3': {'control': 'sample8', 'broad': True},
+            'sample4': {'control': 'sample8', 'broad': True},
+            'sample5': {'control': 'sample9', 'broad': True},
+            'sample6': {'control': 'sample9', 'broad': True}
         }
     }
     with open(fp / 'chipdict_broad.yaml', 'w') as f:
-        yaml.dump(chip_dict_broad, f, default_flow_style=False, default_style=None)
+        yaml.dump(chip_dict_broad, f)
 
     chip_dict_no_control ={
         'chip_dict': {
-            'sample1': {'control': None, 'broad': 'False'},
-            'sample2': {'control': None, 'broad': 'False'},
-            'sample3': {'control': None, 'broad': 'False'},
-            'sample4': {'control': None, 'broad': 'False'},
-            'sample5': {'control': None, 'broad': 'False'},
-            'sample6': {'control': None, 'broad': 'False'}
+            'sample1': {'control': None, 'broad': False},
+            'sample2': {'control': None, 'broad': False},
+            'sample3': {'control': None, 'broad': False},
+            'sample4': {'control': None, 'broad': False},
+            'sample5': {'control': None, 'broad': False},
+            'sample6': {'control': None, 'broad': False}
         }
     }
     with open(fp / 'chipdict_noControl.yaml', 'w') as f:
-        yaml.dump(chip_dict_no_control, f, default_flow_style=False, default_style=None)
+        yaml.dump(chip_dict_no_control, f)
 
 
     chip_dict_simple ={
         'chip_dict': {
-            'sample1': {'control': 'sample3', 'broad': 'False'},
-            'sample2': {'control': 'sample3', 'broad': 'False'},
-            'sample4': {'control': 'sample6', 'broad': 'False'},
-            'sample5': {'control': 'sample6', 'broad': 'False'}
+            'sample1': {'control': 'sample3', 'broad': False},
+            'sample2': {'control': 'sample3', 'broad': False},
+            'sample4': {'control': 'sample6', 'broad': False},
+            'sample5': {'control': 'sample6', 'broad': False}
         }
     }
     with open(fp / 'chipdict_simple.yaml', 'w') as f:
-        yaml.dump(chip_dict_simple, f, default_flow_style=False, default_style=None)
+        yaml.dump(chip_dict_simple, f)
 
 @pytest.fixture(scope="session")
 def ifs(tmp_path_factory):
@@ -500,7 +503,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 77
+        assert parseSpOut(_p) == 59
     def test_broad(self, ifs):
         ci = [
             "ChIP-seq",
@@ -534,7 +537,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 74
+        assert parseSpOut(_p) == 56
     def test_seacr(self, ifs):
         ci = [
             "ChIP-seq",
@@ -552,7 +555,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 89
+        assert parseSpOut(_p) == 71
     def test_seacr_spikein(self, ifs):
         ci = [
             "ChIP-seq",
@@ -571,7 +574,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 139
+        assert parseSpOut(_p) == 112
     def test_SE(self, ifs):
         ci = [
             "ChIP-seq",
@@ -588,7 +591,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 77
+        assert parseSpOut(_p) == 59
     def test_l2ratio(self, ifs):
         ci = [
             "ChIP-seq",
@@ -606,7 +609,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 71
+        assert parseSpOut(_p) == 53
     def test_default_noInput(self, ifs):
         ci = [
             "ChIP-seq",
@@ -622,7 +625,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 56
+        assert parseSpOut(_p) == 38
     def test_genrich_noInput(self, ifs):
         ci = [
             "ChIP-seq",
@@ -640,7 +643,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 50
+        assert parseSpOut(_p) == 32
     def test_seacr_noInput(self, ifs):
         ci = [
             "ChIP-seq",
@@ -658,7 +661,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 62
+        assert parseSpOut(_p) == 44
     def test_seacr_spikein_noInput(self, ifs):
         ci = [
             "ChIP-seq",
@@ -677,7 +680,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 89
+        assert parseSpOut(_p) == 65
     def test_frombam(self, ifs):
         ci = [
             "ChIP-seq",
@@ -695,7 +698,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 137
+        assert parseSpOut(_p) == 119
     def test_frombam_noInput(self, ifs):
         ci = [
             "ChIP-seq",
@@ -713,7 +716,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 98
+        assert parseSpOut(_p) == 80
     def test_spikein(self, ifs):
         ci = [
             "ChIP-seq",
@@ -730,7 +733,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 124
+        assert parseSpOut(_p) == 106
     def test_spikein_noInput(self, ifs):
         ci = [
             "ChIP-seq",
@@ -747,7 +750,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 83
+        assert parseSpOut(_p) == 65
     def test_spikeinfrombam(self, ifs):
         ci = [
             "ChIP-seq",
@@ -766,7 +769,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 160
+        assert parseSpOut(_p) == 142
     def test_spikeinfrombamTSSnorm(self, ifs):
         ci = [
             "ChIP-seq",
@@ -787,7 +790,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 136
+        assert parseSpOut(_p) == 118
     def test_spikeinfrombaminputnorm(self, ifs):
         ci = [
             "ChIP-seq",
@@ -808,7 +811,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 133
+        assert parseSpOut(_p) == 115
     def test_allelic(self, ifs):
         ci = [
             "ChIP-seq",
@@ -840,7 +843,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 99
+        assert parseSpOut(_p) == 81
     def test_multicomp_genrich(self, ifs):
         ci = [
             "ChIP-seq",
@@ -858,7 +861,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 100
+        assert parseSpOut(_p) == 82
     def test_multicomp_broad(self, ifs):
         ci = [
             "ChIP-seq",
@@ -892,7 +895,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 159
+        assert parseSpOut(_p) == 141
     def test_multicomp_fromBam_Genrich(self, ifs):
         ci = [
             "ChIP-seq",
@@ -912,7 +915,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 160
+        assert parseSpOut(_p) == 142
     def test_multicomp_spikein(self, ifs):
         ci = [
             "ChIP-seq",
@@ -929,7 +932,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 136
+        assert parseSpOut(_p) == 118
     def test_multicomp_spikein_genrich(self, ifs):
         ci = [
             "ChIP-seq",
@@ -948,7 +951,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 137
+        assert parseSpOut(_p) == 119
     def test_multicomp_spikein_noInput(self, ifs):
         ci = [
             "ChIP-seq",
@@ -965,7 +968,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 99
+        assert parseSpOut(_p) == 81
     def test_multicomp_spikein_noInput_Genrich(self, ifs):
         ci = [
             "ChIP-seq",
@@ -984,7 +987,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 97
+        assert parseSpOut(_p) == 79
     def test_multicomp_spikein_fromBam(self, ifs):
         ci = [
             "ChIP-seq",
@@ -1003,7 +1006,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 172
+        assert parseSpOut(_p) == 154
     def test_multicomp_spikein_fromBam_genrich(self, ifs):
         ci = [
             "ChIP-seq",
@@ -1024,7 +1027,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 173
+        assert parseSpOut(_p) == 155
     def test_multicomp_spikein_fromBam_noInput(self, ifs):
         ci = [
             "ChIP-seq",
@@ -1043,7 +1046,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 123
+        assert parseSpOut(_p) == 105
     def test_multicomp_spikein_fromBam_noInput_genrich(self, ifs):
         ci = [
             "ChIP-seq",
@@ -1064,7 +1067,7 @@ class TestChIPseq:
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 121
+        assert parseSpOut(_p) == 103
 
 class TestmRNAseq:
     def test_default(self, ifs):


### PR DESCRIPTION
Should take care of the pytest issues with SEACR runs, and all the ones where the jobcount is also aberrant.
ruamel is not an explicit dependency yet. Testing wether this should be the case.