### PR TITLE
bugfix 2.8.0

### DIFF
--- a/snakePipes/shared/rscripts/WGBS_QC_report_template.Rmd
+++ b/snakePipes/shared/rscripts/WGBS_QC_report_template.Rmd
@@ -133,7 +133,7 @@ sampleNames(bs) = gsub("MethylDackel/", "", sampleNames(bs))
 sampleNames(bs) = gsub("_CpG.bedGraph", "", sampleNames(bs))
 save.image(file="QC_metrics/Session.RData")
 
-if(length(snakemake@input[["bedGraphs"]])>1){
+if(length(snakemake@input[["bedGraphs"]])>2){
 
     methyl = logit(getBSseq(bs, type="M") / getBSseq(bs, type="Cov"), adjust=1e-3)
     rv = DelayedMatrixStats::rowVars(methyl)
@@ -141,18 +141,18 @@ if(length(snakemake@input[["bedGraphs"]])>1){
     IDX = order(rv, decreasing=TRUE)[1:tot]
     x = PCA(t(methyl[IDX,]), graph=FALSE)
     plot.PCA(x, choix="ind", title="PCA of methylation values")} else {
-message("Cannot compute PCA for methylation on only 1 sample. Skipping.")
+message("Cannot compute PCA for methylation on only 1 or 2 samples. Skipping.")
 }
 ```
 
 ```{r warning=FALSE, message=FALSE}
-if(length(snakemake@input[["bedGraphs"]])>1){
+if(length(snakemake@input[["bedGraphs"]])>2){
     coverage = getBSseq(bs, type="Cov")
     rv = DelayedMatrixStats::rowVars(coverage)
     IDX = order(rv, decreasing=TRUE)[1:tot]
     x = PCA(t(coverage), graph=FALSE)
     plot.PCA(x, choix="ind", title="PCA of coverage")} else {
-message("Cannot compute PCA for coverage on only 1 sample. Skipping.")
+message("Cannot compute PCA for coverage on only 1 or 2 samples. Skipping.")
 }
 ```
 

--- a/snakePipes/shared/rules/WGBS.snakefile
+++ b/snakePipes/shared/rules/WGBS.snakefile
@@ -95,7 +95,7 @@ if not skipBamQC:
         shell: """
             TMPDIR={params.tempDir}
             MYTEMP=$(mktemp -d "${{TMPDIR:-/tmp}}"/snakepipes.XXXXXXXXXX)
-            sambamba markdup -t {threads} --tmpdir "$MYTEMP/{wildcards.sample}" "{input[0]}" "{output}" >> {log.out} 2> {log.err}
+            sambamba markdup --overflow-list-size 600000 -t {threads} --tmpdir "$MYTEMP/{wildcards.sample}" "{input[0]}" "{output}" >> {log.out} 2> {log.err}
             rm -rf "$MYTEMP"
             """
 

--- a/snakePipes/shared/rules/envs/hic.yaml
+++ b/snakePipes/shared/rules/envs/hic.yaml
@@ -3,7 +3,7 @@ channels:
  - conda-forge
  - bioconda
 dependencies:
- - hicexplorer = 3.7.2
+ - hicexplorer = 3.7.3
  - bwa = 0.7.17
  - bwa-mem2 = 2.2.1
  - samtools = 1.15.1

--- a/snakePipes/shared/rules/envs/shared.yaml
+++ b/snakePipes/shared/rules/envs/shared.yaml
@@ -3,18 +3,18 @@ channels:
  - conda-forge
  - bioconda
 dependencies:
- - python = 3.7.12 #This can be changed together with the update of deeptools to the next version
- - deeptools = 3.5.1
- - seqtk = 1.3
- - pigz = 2.6
- - snpsplit = 0.5.0
- - samtools = 1.15.1
- - fastqc = 0.11.9
- - cutadapt = 4.1
- - trim-galore = 0.6.5
- - multiqc = 1.12
- - fastp = 0.23.2
- - umi_tools = 1.1.2
- - fq = 0.10.0
- - pybigwig = 0.3.18
+ - python = 3.10.13
+ - deeptools = 3.5.4
+ - seqtk = 1.4
+ - pigz = 2.8
+ - snpsplit = 0.6.0
+ - samtools = 1.19.2
+ - fastqc = 0.12.1
+ - cutadapt = 4.6
+ - trim-galore = 0.6.10
+ - multiqc = 1.19
+ - fastp = 0.23.4
+ - umi_tools = 1.1.4
+ - fq = 0.11.0
+ - pybigwig = 0.3.22
  


### PR DESCRIPTION
multiqc and py 3.7 are not compatible anymore and needs a more recent python version. This is an attempt to (drastically) boost the shared_env versions. Currently still testing all the workflows for any hiccups

- [x] ncRNA
- [x] ATAC
- [x] ChIP
- [x] DNA
- [x] mRNA
- [x] mRNA - allelic
- [x] HiC
- [x] scRNA
- [x] WGBS