### PR TITLE
Pairtools ci

### DIFF
--- a/.github/conda_ci.yml
+++ b/.github/conda_ci.yml
@@ -1,8 +1,4 @@
-name: condaBuild_CI
-channels:
-  - uibcdf
-  - conda-forge
-  - bioconda
+name: conda_ci
 dependencies:
   - python=3.11
   - anaconda-client

--- a/.github/snakePipesEnvCI.yml
+++ b/.github/snakePipesEnvCI.yml
@@ -1,3 +1,0 @@
-name: snakePipes_CI
-dependencies:
-  - python >= 3.11

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -9,10 +9,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          environment-file: .github/condaBuildCI.yml
-          auto-update-conda: false
-          auto-activate-base: false
-          show-channel-urls: true
+          environment-file: .github/conda_ci.yml
+          condarc-file: .github/condarc.yml
       - name: buildSnakePipes
         uses: uibcdf/action-build-and-upload-conda-packages@v1.3.0
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,8 +21,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: pip
       run: |
-        pip install {{ matrix.optdeps }}
+        pip install ${{ matrix.optdeps }}
   docs:
+    needs: pip
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -38,6 +39,7 @@ jobs:
         cd docs
         make html
   lint:
+    needs: pip
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -51,6 +53,7 @@ jobs:
       run: |
         ruff check .
   CI:
+    needs: pip
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,11 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: actions/setup-python@v5
       with:
-        environment-file: .github/snakePipesEnvCI.yml
-        activate-environment: snakePipes_CI
-        condarc-file: .github/condarc.yml
+        python-version: 3.11
     - name: Install snakePipes
       run: |
         pip install .[docs]
@@ -29,11 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: actions/setup-python@v5
       with:
-        environment-file: .github/snakePipesEnvCI.yml
-        activate-environment: snakePipes_CI
-        condarc-file: .github/condarc.yml
+        python-version: 3.11
     - name: Install snakePipes
       run: |
         pip install .[actions]
@@ -46,8 +42,8 @@ jobs:
     - uses: actions/checkout@v4
     - uses: conda-incubator/setup-miniconda@v3
       with:
-        environment-file: .github/snakePipesEnvCI.yml
-        activate-environment: snakePipes_CI
+        environment-file: .github/conda_ci.yml
+        activate-environment: conda_ci
         condarc-file: .github/condarc.yml
     - name: Install snakePipes
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,6 +8,20 @@ defaults:
 
 
 jobs:
+  pip:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12']
+        optdeps: [".", ".[actions]", ".[docs]"]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: pip
+      run: |
+        pip install {{ matrix.optdeps }}
   docs:
     runs-on: ubuntu-latest
     steps:
@@ -90,8 +104,8 @@ jobs:
     - uses: actions/checkout@v4
     - uses: conda-incubator/setup-miniconda@v3
       with:
-        environment-file: .github/snakePipesEnvCI.yml
-        activate-environment: snakePipes_CI
+        environment-file: .github/conda_ci.yml
+        activate-environment: conda_ci
         condarc-file: .github/condarc.yml
     - name: install snakePipes
       run: |

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -38,8 +38,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          environment-file: .github/snakePipesEnvCI.yml
-          activate-environment: snakePipes_CI
+          environment-file: .github/conda_ci.yml
+          activate-environment: conda_ci
           condarc-file: .github/condarc.yml
       - name: install snakePipes_OSX
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,8 +23,8 @@ jobs:
         STAR --runThreadN 4 --runMode genomeGenerate --genomeDir tests/data/mRNA_STAR --genomeFastaFiles genome_chr17.fa --sjdbGTFfile genes_chr17.gtf --sjdbOverhang 100 --genomeSAindexNbases 12
     - uses: conda-incubator/setup-miniconda@v3
       with:
-        environment-file: .github/snakePipesEnvCI.yml
-        activate-environment: snakePipes_CI
+        environment-file: .github/conda_ci.yml
+        activate-environment: conda_ci
         condarc-file: .github/condarc.yml
     - name: Install snakePipes
       run: |
@@ -40,8 +40,8 @@ jobs:
     - uses: actions/checkout@v4
     - uses: conda-incubator/setup-miniconda@v3
       with:
-        environment-file: .github/snakePipesEnvCI.yml
-        activate-environment: snakePipes_CI
+        environment-file: .github/conda_ci.yml
+        activate-environment: conda_ci
         condarc-file: .github/condarc.yml
     - name: Install snakePipes
       run: |


### PR DESCRIPTION
simplify CI tests, include pip install for py versions 3.11 / 3.12 & opt deps