### PR TITLE
Pairtools finaltweaks

### DIFF
--- a/snakePipes/shared/rules/SNPsplit.snakefile
+++ b/snakePipes/shared/rules/SNPsplit.snakefile
@@ -7,7 +7,7 @@ if aligner == "Bowtie2":
             bam = "filtered_bam/{sample}.filtered.bam"
         output:
             targetbam = expand("allelic_bams/{{sample}}.filtered.{suffix}.bam", suffix = ['allele_flagged', 'genome1', 'genome2', 'unassigned']),
-            tempbam = temp("filtered_bam/{sample}.filtered.sortedByName.bam"),
+            #tempbam = temp("filtered_bam/{sample}.filtered.sortedByName.bam"),
             rep1 = "allelic_bams/{sample}.filtered.SNPsplit_report.yaml",
             rep2 = "allelic_bams/{sample}.filtered.SNPsplit_sort.yaml"
         params:
@@ -25,7 +25,7 @@ elif aligner == "STAR" or aligner == "EXTERNAL_BAM":
             bam = aligner+"/{sample}.bam"
         output:
             targetbam = expand("allelic_bams/{{sample}}.{suffix}.bam", suffix = ['allele_flagged', 'genome1', 'genome2', 'unassigned']),
-            tempbam = temp(aligner+"/{sample}.sortedByName.bam"),
+            #tempbam = temp(aligner+"/{sample}.sortedByName.bam"),
             rep1 = "allelic_bams/{sample}.SNPsplit_report.yaml",
             rep2 = "allelic_bams/{sample}.SNPsplit_sort.yaml"
         params:

--- a/snakePipes/shared/rules/createIndices.snakefile
+++ b/snakePipes/shared/rules/createIndices.snakefile
@@ -54,7 +54,7 @@ else:
         params:
             spikeinExt = spikeinExt
         shell: """
-            sed -r 's/[[:space:]]+/{spikeinExt} /' {input} > {output}
+            sed '/^>/ s/$/{spikeinExt}/' {input} > {output}
         """
 
     rule createGenomeFasta:

--- a/snakePipes/shared/rules/three_prime_seq.snakefile
+++ b/snakePipes/shared/rules/three_prime_seq.snakefile
@@ -1,11 +1,8 @@
-# adapted from Andrew Rezansoff's 3' seq pipeline tools
-# /data/hilgers/group/rezansoff/3seq_pipeline_tools/
-
 from pathlib import Path
 import pandas as pd
 
 # prevent wildcards from picking up directories
-wildcard_constraints: sample="[^(\/)]+"
+wildcard_constraints: sample="[^(/)]+"
 
 # read in sampleSheet metadata to merge replicates for preprocess_cluster_pas 
 sample_metadata = pd.read_table(sampleSheet, index_col=None)
@@ -26,30 +23,7 @@ def get_outdir(folder_name,sampleSheet):
     sample_name = os.path.splitext(os.path.basename(str(sampleSheet)))[0]
     return("{}_{}".format(folder_name, sample_name))
 
-
-# TODO: 
-# 3. check why cmatrix_filtered is commented out - OK
-# 5. re-implement clusterPAS?  
-# 6. implement filtering of column 4 of the geneAssociation output - things with multiple hits (i.e. commas) should be filtered out [x]
-# possibly assign cluster to "next" gene annotation (i.e. the closest?) 
-# this would be in signal2gene.py
-# 7. assign unique IDs with _0, _1 to 4th column in clusterPAS output in 5'->3' order to create unique 
-# example is /data/hilgers/group2/rezansoff/sakshiProj/2507_3seq/polyA_annotation_polysome2K/AllSamples_clustered_strict1_fromSortedNumeric.txt -> 
-# /data/hilgers/group2/rezansoff/sakshiProj/2507_3seq/polyA_annotation_polysome2K/AllSamples_clustered_strict1_fromSortedNumeric_uniqIDs.txt
-# this will be run by countReadEnds
-# then possibly DESeq on countReadEnds output
-# understand cmatrix steps? 
-
 tools_dir = Path(maindir) / "shared" / "tools"
-
-# trimming done using STAR and fastp
-
-# rule clusterPAS:
-#     input: 
-#         "three_prime_seq/SampleAll.txt"
-#     conda:
-#         CONDA_SHARED_ENV
-    
 
 rule polyAT: 
     input: 
@@ -214,7 +188,7 @@ rule count_read_ends:
     output:
         counts="three_prime_seq/{sample}_uniqcounts.txt"
     wildcard_constraints:
-        sample="[^\/]+" # no /
+        sample="[^/]+"
     conda:
         CONDA_SHARED_ENV
     params:

--- a/snakePipes/shared/rules/trimming.snakefile
+++ b/snakePipes/shared/rules/trimming.snakefile
@@ -14,7 +14,7 @@ if pairedEnd:
         threads: lambda wildcards: 8 if 8<max_thread else max_thread
         conda: CONDA_SHARED_ENV
         shell: """
-            cutadapt -j {threads} -e 0.1 -q 16 -O 3 --trim-n --minimum-length 25 -a AGATCGGAAGAGC -A AGATCGGAAGAGC {params.opts} \
+            cutadapt -j {threads} -e 0.1 -q 16 -O 3 --trim-n --minimum-length 25 -a CTGTCTCTTATACACATCT -A CTGTCTCTTATACACATCT {params.opts} \
                 -o "{output.r1}" -p "{output.r2}" "{input.r1}" "{input.r2}"
             """
 else:
@@ -30,7 +30,7 @@ else:
         threads: lambda wildcards: 8 if 8<max_thread else max_thread
         conda: CONDA_SHARED_ENV
         shell: """
-            cutadapt -j {threads} -e 0.1 -q 16 -O 3 --trim-n --minimum-length 25 -a AGATCGGAAGAGC {params.opts} \
+            cutadapt -j {threads} -e 0.1 -q 16 -O 3 --trim-n --minimum-length 25 -a CTGTCTCTTATACACATCT {params.opts} \
                 -o "{output}" "{input.r1}"
             """
 

--- a/snakePipes/snakePipes.py
+++ b/snakePipes/snakePipes.py
@@ -316,9 +316,9 @@ def createCondaEnvs(args):
         numberEnvs = len(args.only)
     envNum = 0
     for envName, env in cof.set_env_yamls().items():
-        envNum += 1
         if args.only is not None and envName not in args.only:
             continue
+        envNum += 1
         # Hash the file ala snakemake
         md5hash = hashlib.md5()
         md5hash.update(condaEnvDir.encode())

--- a/snakePipes/snakePipes.py
+++ b/snakePipes/snakePipes.py
@@ -294,9 +294,26 @@ def createCondaEnvs(args):
     if condaEnvDir[-1] == '/':
         condaEnvDir = condaEnvDir[:-1]
 
-    print(f"CondaEnvDir detected as: {condaEnvDir}, from {_prefsource}")
+    print(f"profile used: {profilePath}")
+    print(f"CondaEnvDir detected as: {condaEnvDir}, from {_prefsource}\n")
+
+    # if mamba is not installed, conda-frontend should be set
+    if not shutil.which('mamba') and 'conda-frontend' not in _p:
+        print(
+            f"WARNING: No mamba detected in your path and conda-frontend not set. Set 'conda-fronted: conda' in {profilePath.name}"
+        )
+    if 'use-conda' not in _p:
+        print(
+            f"WARNING: Your profile ({profilePath.name}) should have 'use-conda: True' !"
+        )
+    if 'conda-prefix' not in _p:
+        print(
+            f"WARNING: Your profile ({profilePath.name}) does not have 'conda-prefix' set. Environments will go in your default envs folder."
+        )
 
     numberEnvs = len(cof.set_env_yamls().keys())
+    if args.only is not None:
+        numberEnvs = len(args.only)
     envNum = 0
     for envName, env in cof.set_env_yamls().items():
         envNum += 1


### PR DESCRIPTION
- comment out temp bam files SNPsplit rule, as they are not (or no longer?) generated.
- regex fixes in createIndices / threeprimeseq
- purge some todo / bloated comments in threeprimeseq 
- default trimming is done for illumina stranded adapter instead of TruSeq
- basic profile checks upon invocation of createEnvs
- createEnvs counter fixed if --only is set

closes #1031, #1029 