### PR TITLE
drop log as omitted by profile

### DIFF
--- a/snakePipes/shared/rules/split_bam_ops_ChIP_spikein.snakefile
+++ b/snakePipes/shared/rules/split_bam_ops_ChIP_spikein.snakefile
@@ -107,7 +107,7 @@ rule concatenate_scaling_factors:
         scale_factors_chip = "split_deepTools_qc/multiBamSummary/{part}.ChIP.scaling_factors.txt"
     output: "split_deepTools_qc/multiBamSummary/{part}.concatenated.scaling_factors.txt"
     shell: """
-        cat {input.scale_factors_input} {input.scale_factors_chip} > {output} 2> {log}
+        cat {input.scale_factors_input} {input.scale_factors_chip} > {output}
     """
 
 


### PR DESCRIPTION
Fixes an internally reported bug, where {log} out wasn't omitted from the shell command (deprecated with profile use).