### PR TITLE
capturing sambamba/markdup log for MultiQC report

### DIFF
--- a/snakePipes/shared/rules/ChiP-seq_qc_report.snakefile
+++ b/snakePipes/shared/rules/ChiP-seq_qc_report.snakefile
@@ -1,7 +1,7 @@
 #############convert sambamba report format########
 rule convert_flagstat_output:
     input:
-        "Sambamba/{sample}.markdup.txt"
+        "Sambamba/{sample}.flagstat.txt"
     output:
         temp("Sambamba/{sample}.dup.converted.tsv")
     shell: """

--- a/snakePipes/shared/rules/LinkBam.snakefile
+++ b/snakePipes/shared/rules/LinkBam.snakefile
@@ -113,7 +113,7 @@ else:
            input:
                aligner + "/{sample}.markdup.bam"
            output:
-               "Sambamba/{sample}.markdup.txt"
+               "Sambamba/{sample}.flagstat.txt"
            conda: CONDA_SAMBAMBA_ENV
            shell: """
                sambamba flagstat -p {input} > {output}

--- a/snakePipes/shared/rules/multiQC.snakefile
+++ b/snakePipes/shared/rules/multiQC.snakefile
@@ -32,7 +32,7 @@ def multiqc_input_check(return_value):
         if aligner=="Bowtie2":
             infiles.append("deepTools_qc/bamPEFragmentSize/fragmentSize.metric.tsv")
             infiles.append(expand("Bowtie2/{sample}.Bowtie2_summary.txt", sample = samples) +
-                    expand("Sambamba/{sample}.markdup.txt", sample = samples) +
+                    expand("Sambamba/{sample}.flagstat.txt", sample = samples) +
                     expand("deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",sample=samples))
             indir += " Sambamba "
             indir += " Bowtie2 "
@@ -42,14 +42,14 @@ def multiqc_input_check(return_value):
                 indir += " Qualimap_qc "
         elif aligner=="bwa":
             infiles.append( expand("bwa/{sample}.bwa_summary.txt", sample = samples) +
-                            expand("Sambamba/{sample}.markdup.txt", sample = samples) +
+                            expand("Sambamba/{sample}.flagstat.txt", sample = samples) +
                             expand("deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",sample=samples))
             indir += " Sambamba "
             indir += " bwa "
             indir += " deepTools_qc "
         elif aligner=="bwa-mem2":
             infiles.append( expand("bwa-mem2/{sample}.bwa-mem2_summary.txt", sample = samples) +
-                            expand("Sambamba/{sample}.markdup.txt", sample = samples) +
+                            expand("Sambamba/{sample}.flagstat.txt", sample = samples) +
                             expand("deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",sample=samples))
             indir += " Sambamba "
             indir += " bwa-mem2 "
@@ -65,7 +65,7 @@ def multiqc_input_check(return_value):
         # must be RNA-mapping, add files as per the mode
         if ( "alignment" in mode or "deepTools_qc" in mode or "three-prime-seq" in mode ) and not "allelic-mapping" in mode and not "allelic-counting" in mode and not "allelic-whatshap" in mode:
             infiles.append( expand(aligner+"/{sample}.markdup.bam", sample = samples) +
-                    expand("Sambamba/{sample}.markdup.txt", sample = samples) +
+                    expand("Sambamba/{sample}.flagstat.txt", sample = samples) +
                     expand("deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",sample=samples)+
                     expand("featureCounts/{sample}.counts.txt", sample = samples))
             indir += aligner + " featureCounts "
@@ -73,7 +73,7 @@ def multiqc_input_check(return_value):
             indir += " deepTools_qc "
         if "allelic-whatshap" in mode and not fromBAM:
             infiles.append( expand(aligner+"/{sample}.markdup.bam", sample = samples) +
-                    expand("Sambamba/{sample}.markdup.txt", sample = samples) +
+                    expand("Sambamba/{sample}.flagstat.txt", sample = samples) +
                     expand("deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",sample=samples))
             infiles.append( expand("allelic_bams/{sample}.{suffix}.sorted.bam", sample = samples,suffix = ['allele_flagged', 'genome1', 'genome2', 'unassigned']) )
             indir += aligner
@@ -128,7 +128,7 @@ def multiqc_input_check(return_value):
         if mode == "STARsolo":
             infiles.append( expand(fastq_dir+"/{sample}"+reads[0]+".fastq.gz", sample = samples) )
             infiles.append( expand(aligner+"/{sample}.markdup.bam", sample = samples) +
-            expand("Sambamba/{sample}.markdup.txt", sample = samples) +
+            expand("Sambamba/{sample}.flagstat.txt", sample = samples) +
             expand("deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt", sample=samples))
             indir += aligner
             indir += " Sambamba "

--- a/snakePipes/shared/rules/sambamba.snakefile
+++ b/snakePipes/shared/rules/sambamba.snakefile
@@ -7,12 +7,12 @@ rule sambamba_markdup:
        input:
            aligner+"/{sample}.sorted.bam"
        output:
-           bam=aligner+"/{sample}.bam"# duplicate marked
+           bam=aligner+"/{sample}.bam",
            log="Sambamba/{sample}.sorted.markdup.txt"
        threads: lambda wildcards: 10 if 10<max_thread else max_thread
        benchmark: aligner + "/.benchmark/sambamba_markdup.{sample}.benchmark"
        params:
-           tempDir = tempDir
+           tempDir = tempDir,
            buffer = "--sort-buffer-size=6000 --overflow-list-size 600000"
        conda: CONDA_SAMBAMBA_ENV
        shell: """

--- a/snakePipes/shared/rules/sambamba.snakefile
+++ b/snakePipes/shared/rules/sambamba.snakefile
@@ -7,16 +7,18 @@ rule sambamba_markdup:
        input:
            aligner+"/{sample}.sorted.bam"
        output:
-           aligner+"/{sample}.bam"# duplicate marked
+           bam=aligner+"/{sample}.bam"# duplicate marked
+           log="Sambamba/{sample}.sorted.markdup.txt"
        threads: lambda wildcards: 10 if 10<max_thread else max_thread
        benchmark: aligner + "/.benchmark/sambamba_markdup.{sample}.benchmark"
        params:
            tempDir = tempDir
+           buffer = "--sort-buffer-size=6000 --overflow-list-size 600000"
        conda: CONDA_SAMBAMBA_ENV
        shell: """
            TMPDIR={params.tempDir}
            MYTEMP=$(mktemp -d "${{TMPDIR:-/tmp}}"/snakepipes.XXXXXXXXXX)
-           sambamba markdup -t {threads} --sort-buffer-size=6000 --overflow-list-size 600000 --tmpdir $MYTEMP {input} {output}
+           sambamba markdup -t {threads} {params.buffer} --tmpdir $MYTEMP {input} {output.bam} > {output.log}
            rm -rf "$MYTEMP"
            """
 
@@ -25,7 +27,7 @@ rule sambamba_flagstat_sorted:
        input:
            aligner+"/{sample}.sorted.bam"
        output:
-           "Sambamba/{sample}.sorted.markdup.txt"
+           "Sambamba/{sample}.sorted.flagstat.txt"
        conda: CONDA_SAMBAMBA_ENV
        threads: lambda wildcards: 10 if 10<max_thread else max_thread
        shell: """
@@ -36,7 +38,7 @@ rule sambamba_flagstat:
        input:
            aligner+"/{sample}.bam"
        output:
-           "Sambamba/{sample}.markdup.txt"
+           "Sambamba/{sample}.flagstat.txt"
        conda: CONDA_SAMBAMBA_ENV
        threads: lambda wildcards: 10 if 10<max_thread else max_thread
        shell: """

--- a/snakePipes/shared/rules/sambamba.snakefile
+++ b/snakePipes/shared/rules/sambamba.snakefile
@@ -7,16 +7,18 @@ rule sambamba_markdup:
        input:
            aligner+"/{sample}.sorted.bam"
        output:
-           aligner+"/{sample}.markdup.bam"# duplicate marked
+           bam=aligner+"/{sample}.markdup.bam"
+       log: "Sambamba/{sample}.markdup.txt"
        threads: lambda wildcards: 10 if 10<max_thread else max_thread
        benchmark: aligner + "/.benchmark/sambamba_markdup.{sample}.benchmark"
        params:
-           tempDir = tempDir
+           tempDir = tempDir,
+           buffer = "--sort-buffer-size=6000 --overflow-list-size 600000"
        conda: CONDA_SAMBAMBA_ENV
        shell: """
            TMPDIR={params.tempDir}
            MYTEMP=$(mktemp -d "${{TMPDIR:-/tmp}}"/snakepipes.XXXXXXXXXX)
-           sambamba markdup -t {threads} --sort-buffer-size=6000 --overflow-list-size 600000 --tmpdir $MYTEMP {input} {output}
+           sambamba markdup -t {threads} {params.buffer} --tmpdir $MYTEMP {input} {output.bam} > {log}
            rm -rf "$MYTEMP"
            """
 
@@ -25,7 +27,7 @@ rule sambamba_flagstat_sorted:
        input:
            aligner+"/{sample}.sorted.bam"
        output:
-           "Sambamba/{sample}.sorted.markdup.txt"
+           "Sambamba/{sample}.sorted.flagstat.txt"
        conda: CONDA_SAMBAMBA_ENV
        threads: lambda wildcards: 10 if 10<max_thread else max_thread
        shell: """
@@ -36,7 +38,7 @@ rule sambamba_flagstat:
        input:
            aligner+"/{sample}.markdup.bam"
        output:
-           "Sambamba/{sample}.markdup.txt"
+           "Sambamba/{sample}.flagstat.txt"
        conda: CONDA_SAMBAMBA_ENV
        threads: lambda wildcards: 10 if 10<max_thread else max_thread
        shell: """

--- a/tests/test_jobcounts.py
+++ b/tests/test_jobcounts.py
@@ -95,7 +95,7 @@ def createTestData(fp, samples=9) -> None:
         (fp / "bam_input" / "sample{}.bam".format(sample)).touch()
         (fp / "bam_input" / "filtered_bam" / "sample{}.filtered.bam".format(sample)).touch()
         (fp / "bam_input" / "filtered_bam" / "sample{}.filtered.bam.bai".format(sample)).touch()
-        (fp / "bam_input" / "Sambamba" / "sample{}.markdup.txt".format(sample)).touch()
+        (fp / "bam_input" / "Sambamba" / "sample{}.flagstat.txt".format(sample)).touch()
         (fp / "bam_input" / "bamCoverage" / "sample{}.filtered.seq_depth_norm.bw".format(sample)).touch()
         (fp / "bam_input" / "bamCoverage" / "sample{}.host_scaled.BYspikein.bw".format(sample)).touch()
         (fp / "bam_input" / "split_bam" / "sample{}_host.bam".format(sample)).touch()
@@ -115,7 +115,7 @@ def createTestData(fp, samples=9) -> None:
         (fp / "allelic_bam_input" / "filtered_bam" / "sample{}.filtered.bam.bai".format(sample)).touch()
         (fp / "allelic_bam_input" / "split_bam" / "sample{}_host.bam".format(sample)).touch()
         (fp / "allelic_bam_input" / "split_bam" / "sample{}_host.bam.bai".format(sample)).touch()
-        (fp / "allelic_bam_input" / "Sambamba" / "sample{}.markdup.txt".format(sample)).touch()
+        (fp / "allelic_bam_input" / "Sambamba" / "sample{}.flagstat.txt".format(sample)).touch()
         (fp / "allelic_bam_input" / "bamCoverage" / "allele_specific" / "sample{}.genome1.seq_depth_norm.bw".format(sample)).touch()
 
     # Create organism.yaml


### PR DESCRIPTION
Sambamba markdup log is needed for MultiQC report, this  changes captures that and renamed the flagstat outptus