### PR TITLE
tests: fix makePairs job count regression from #1175

### DIFF
--- a/tests/test_jobcounts.py
+++ b/tests/test_jobcounts.py
@@ -299,7 +299,7 @@ class TestmakePairs():
         print(' '.join([str(i) for i in ci]))
         _p = sp.run(ci, capture_output=True, text=True)
         assert _p.returncode == 0
-        assert parseSpOut(_p) == 185
+        assert parseSpOut(_p) == 176
 
     def test_dag(self, ifs):
         ci = [


### PR DESCRIPTION
## Summary
`test_default`'s expected job count was set to 185 in #1175, correct only for the intermediate broken state where both trimmers ran because `bwa_mapping` ignored the `trimmer` setting. The same PR also fixed that bug, which removed the redundant fastp jobs and dropped the real count back to 176, its value before #1175. CI on develop has been failing since the merge because the test was never updated for this side effect.

## Changes
- `tests/test_jobcounts.py`: `TestmakePairs::test_default` expected job count, 185 → 176

## Test plan
- [x] Confirmed 176 is the actual dry-run count on current develop (from the failing CI_jobcounts run on the merge commit)
- [ ] CI passes on this PR