### PR TITLE
fix: revert hsa URL corruption, pin CI actions, fix snakefmt crash

### DIFF
--- a/.codespell-ignore.txt
+++ b/.codespell-ignore.txt
@@ -1,2 +1,3 @@
 te
 bais
+hsa

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -2,12 +2,17 @@ name: conda-build
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
   condaBuild:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
         with:
           environment-file: .github/conda_ci.yml
           condarc-file: .github/condarc.yml
@@ -15,7 +20,7 @@ jobs:
       - name: Install conda-build in base environment
         run: conda install -n base -c conda-forge conda-build
       - name: buildSnakePipes
-        uses: uibcdf/action-build-and-upload-conda-packages@v1.4.0
+        uses: uibcdf/action-build-and-upload-conda-packages@b06165145a25b9c8bcb2d2b24682ad0d8e494ce7 # v1.4.0
         with:
           meta_yaml_dir: conda-recipe
           python-version: 3.11

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,9 @@ name: linux
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 defaults:
   run:
       shell: bash -l {0}
@@ -15,8 +18,10 @@ jobs:
         python-version: ['3.11']
         optdeps: [".", ".[actions]", ".[docs]"]
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: pip
@@ -26,8 +31,10 @@ jobs:
     needs: pip
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: 3.11
     - name: Install snakePipes
@@ -42,19 +49,21 @@ jobs:
     needs: pip
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: 3.11
-    - uses: pre-commit/action@v3.0.1
-      env:
-        SKIP: zizmor,snakefmt
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
   CI:
     needs: pip
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        persist-credentials: false
+    - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
       with:
         environment-file: .github/conda_ci.yml
         activate-environment: conda_ci
@@ -103,8 +112,10 @@ jobs:
         ]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        persist-credentials: false
+    - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
       with:
         environment-file: .github/conda_ci.yml
         activate-environment: conda_ci

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -2,6 +2,9 @@ name: osx
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 defaults:
   run:
       shell: bash -l {0}
@@ -36,8 +39,10 @@ jobs:
         ]
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
         with:
           environment-file: .github/conda_ci.yml
           activate-environment: conda_ci

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,9 @@ name: pytest
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 defaults:
   run:
       shell: bash -l {0}
@@ -10,8 +13,10 @@ jobs:
   test_mRNA:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        persist-credentials: false
+    - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
       with:
         environment-file: snakePipes/shared/rules/envs/rna_seq.yaml
         activate-environment: snakepipes_RNAseq_environment_3.0
@@ -21,7 +26,7 @@ jobs:
         gunzip -c tests/data/genomes/genome_chr17.fa.gz > genome_chr17.fa
         gunzip -c tests/data/genomes/genes_chr17.gtf.gz > genes_chr17.gtf
         STAR --runThreadN 4 --runMode genomeGenerate --genomeDir tests/data/mRNA_STAR --genomeFastaFiles genome_chr17.fa --sjdbGTFfile genes_chr17.gtf --sjdbOverhang 100 --genomeSAindexNbases 12
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
       with:
         environment-file: .github/conda_ci.yml
         activate-environment: conda_ci
@@ -37,8 +42,10 @@ jobs:
   CI_jobcounts:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        persist-credentials: false
+    - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
       with:
         environment-file: .github/conda_ci.yml
         activate-environment: conda_ci

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,6 @@ ci:
   autoupdate_branch: "master"
   autoupdate_commit_msg: "pre-commit.ci autoupdate"
   autoupdate_schedule: monthly
-  # zizmor needs a workflow permissions/pinning pass; snakefmt crashes on
-  # snakePipes/workflows/preprocessing/Snakefile (two include: statements
-  # under one if: block confuse its block parser). Skipping both until fixed.
-  skip: [zizmor, snakefmt]
   submodules: false
 
 repos:

--- a/snakePipes/shared/tools/smallrna/common.py
+++ b/snakePipes/shared/tools/smallrna/common.py
@@ -15,7 +15,7 @@ from pathlib import Path
 UCSC_BASE = "https://hgdownload.soe.ucsc.edu/goldenPath"
 
 MIRBASE_URLS = {
-    "human": "https://www.mirbase.org/download/has.gff3",
+    "human": "https://www.mirbase.org/download/hsa.gff3",
     "mouse": "https://www.mirbase.org/download/mmu.gff3",
     "drosophila": "https://www.mirbase.org/download/dme.gff3",
 }

--- a/snakePipes/workflows/ATACseq/Snakefile
+++ b/snakePipes/workflows/ATACseq/Snakefile
@@ -5,49 +5,55 @@ import itertools
 
 ### snakemake_workflows initialization ########################################
 maindir = os.path.dirname(os.path.dirname(workflow.basedir))
-workflow_rscripts=os.path.join(maindir, "shared", "rscripts")
+workflow_rscripts = os.path.join(maindir, "shared", "rscripts")
 
 # load conda ENVs (path is relative to "shared/rules" directory)
 globals().update(cf.set_env_yamls())
 
 # load config file
-globals().update(cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"]))
+globals().update(
+    cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"])
+)
 # load organism-specific data, i.e. genome indices, annotation, etc.
 globals().update(cf.load_organism_data(genome, maindir, config["verbose"]))
 # return the pipeline version in the log
 cf.get_version()
 
-outdir_MACS2 = 'MACS2/'
-short_bams = 'short_bams/'
-outdir_ATACqc = 'MACS2_QC/'
-deeptools_ATAC='deepTools_ATAC/'
+outdir_MACS2 = "MACS2/"
+short_bams = "short_bams/"
+outdir_ATACqc = "MACS2_QC/"
+deeptools_ATAC = "deepTools_ATAC/"
+
 
 # do workflow specific stuff now
 include: os.path.join(workflow.basedir, "internals.snakefile")
-
 ### include modules of other snakefiles ########################################
 ################################################################################
 # Import deeptools cmds
 include: os.path.join(maindir, "shared", "tools", "deeptools_cmds.snakefile")
 
+
 if fromBAM:
+
     include: os.path.join(maindir, "shared", "rules", "LinkBam.snakefile")
     include: os.path.join(maindir, "shared", "rules", "deepTools_qc.snakefile")
 
+
 # Import deeptools ATAC
 include: os.path.join(maindir, "shared", "rules", "deepTools_ATAC.snakefile")
-
-#import multiQC
+# import multiQC
 include: os.path.join(maindir, "shared", "rules", "multiQC.snakefile")
-
 # ATACseq open chromatin
 include: os.path.join(maindir, "shared", "rules", "ATAC.snakefile")
-
 # ATAC QC open chromatin
 include: os.path.join(maindir, "shared", "rules", "ATAC_qc.snakefile")
 
+
 # flags for allelic mode
-if os.path.isdir(os.path.join(workingdir, 'allelic_bams')) and os.listdir(os.path.join(workingdir, 'allelic_bams')) != []:
+if (
+    os.path.isdir(os.path.join(workingdir, "allelic_bams"))
+    and os.listdir(os.path.join(workingdir, "allelic_bams")) != []
+):
     allele_info = True
 else:
     allele_info = False
@@ -58,59 +64,151 @@ chip_samples = samples
 pairedEnd = True
 if sampleSheet:
     if not isMultipleComparison:
+
         include: os.path.join(maindir, "shared", "rules", "CSAW.singleComp.snakefile")
         include: os.path.join(maindir, "shared", "rules", "nearestGene.singleComp.snakefile")
+
     else:
+
         include: os.path.join(maindir, "shared", "rules", "CSAW.multiComp.snakefile")
         include: os.path.join(maindir, "shared", "rules", "nearestGene.multiComp.snakefile")
     include: os.path.join(maindir, "shared", "rules", "filterGTF.snakefile")
 
+
 ## add outputs as asked
 def run_deepTools_allelic():
     file_list = []
-    if os.path.isdir('allelic_bams') and os.listdir('allelic_bams') != []:
-        file_list.append( [
-        os.path.join(deeptools_ATAC, "plotFingerprint/plotFingerprint.metrics_allelic.txt")
-         ] )
-    return(file_list)
+    if os.path.isdir("allelic_bams") and os.listdir("allelic_bams") != []:
+        file_list.append(
+            [
+                os.path.join(
+                    deeptools_ATAC,
+                    "plotFingerprint/plotFingerprint.metrics_allelic.txt",
+                )
+            ]
+        )
+    return file_list
+
 
 def run_CSAW():
     if sampleSheet:
         if not isMultipleComparison:
-            file_list=["CSAW_{}_{}/CSAW.session_info.txt".format(peakCaller, sample_name),
-                   "Annotation/genes.filtered.symbol","Annotation/genes.filtered.t2g",
-                   "CSAW_{}_{}/CSAW.Stats_report.html".format(peakCaller, sample_name)]
-            file_list.append([os.path.join("CSAW_{}_{}".format(peakCaller, sample_name), x) \
-                         for x in list(itertools.chain.from_iterable([expand("CSAW.{change_dir}.cov.matrix",\
-                         change_dir=change_direction),expand("CSAW.{change_dir}.cov.heatmap.png",change_dir=change_direction)]))])
-            file_list.append([os.path.join("AnnotatedResults_{}_{}".format(peakCaller, sample_name), x) \
-                         for x in list(itertools.chain.from_iterable([expand("Filtered.results.{change_dir}_withNearestGene.txt",\
-                         change_dir=change_direction)]))])
+            file_list = [
+                "CSAW_{}_{}/CSAW.session_info.txt".format(peakCaller, sample_name),
+                "Annotation/genes.filtered.symbol",
+                "Annotation/genes.filtered.t2g",
+                "CSAW_{}_{}/CSAW.Stats_report.html".format(peakCaller, sample_name),
+            ]
+            file_list.append(
+                [
+                    os.path.join("CSAW_{}_{}".format(peakCaller, sample_name), x)
+                    for x in list(
+                        itertools.chain.from_iterable(
+                            [
+                                expand(
+                                    "CSAW.{change_dir}.cov.matrix",
+                                    change_dir=change_direction,
+                                ),
+                                expand(
+                                    "CSAW.{change_dir}.cov.heatmap.png",
+                                    change_dir=change_direction,
+                                ),
+                            ]
+                        )
+                    )
+                ]
+            )
+            file_list.append(
+                [
+                    os.path.join(
+                        "AnnotatedResults_{}_{}".format(peakCaller, sample_name), x
+                    )
+                    for x in list(
+                        itertools.chain.from_iterable(
+                            [
+                                expand(
+                                    "Filtered.results.{change_dir}_withNearestGene.txt",
+                                    change_dir=change_direction,
+                                )
+                            ]
+                        )
+                    )
+                ]
+            )
         else:
-            file_list=expand("CSAW_{}_{}/CSAW.session_info.txt".format(peakCaller, sample_name + ".{compGroup}"),compGroup=cf.returnComparisonGroups(sampleSheet))
-            file_list.append(["Annotation/genes.filtered.symbol","Annotation/genes.filtered.t2g",expand("CSAW_{}_{}/CSAW.Stats_report.html".format(peakCaller, sample_name + ".{compGroup}"),compGroup=cf.returnComparisonGroups(sampleSheet))])
-            file_list.append([expand("CSAW_{}_{}".format(peakCaller, sample_name + ".{compGroup}") + "/CSAW.{change_dir}.cov.matrix",change_dir=change_direction,compGroup=cf.returnComparisonGroups(sampleSheet)),
-                  expand("CSAW_{}_{}".format(peakCaller, sample_name + ".{compGroup}") +"/CSAW.{change_dir}.cov.heatmap.png",change_dir=change_direction,compGroup=cf.returnComparisonGroups(sampleSheet)
-                  )])
-            file_list.append(expand("AnnotatedResults_{}_{}".format(peakCaller,sample_name + ".{compGroup}") + "/Filtered.results.{change_dir}_withNearestGene.txt",change_dir=change_direction, compGroup=cf.returnComparisonGroups(sampleSheet)))
-        return( file_list )
+            file_list = expand(
+                "CSAW_{}_{}/CSAW.session_info.txt".format(
+                    peakCaller, sample_name + ".{compGroup}"
+                ),
+                compGroup=cf.returnComparisonGroups(sampleSheet),
+            )
+            file_list.append(
+                [
+                    "Annotation/genes.filtered.symbol",
+                    "Annotation/genes.filtered.t2g",
+                    expand(
+                        "CSAW_{}_{}/CSAW.Stats_report.html".format(
+                            peakCaller, sample_name + ".{compGroup}"
+                        ),
+                        compGroup=cf.returnComparisonGroups(sampleSheet),
+                    ),
+                ]
+            )
+            file_list.append(
+                [
+                    expand(
+                        "CSAW_{}_{}".format(peakCaller, sample_name + ".{compGroup}")
+                        + "/CSAW.{change_dir}.cov.matrix",
+                        change_dir=change_direction,
+                        compGroup=cf.returnComparisonGroups(sampleSheet),
+                    ),
+                    expand(
+                        "CSAW_{}_{}".format(peakCaller, sample_name + ".{compGroup}")
+                        + "/CSAW.{change_dir}.cov.heatmap.png",
+                        change_dir=change_direction,
+                        compGroup=cf.returnComparisonGroups(sampleSheet),
+                    ),
+                ]
+            )
+            file_list.append(
+                expand(
+                    "AnnotatedResults_{}_{}".format(
+                        peakCaller, sample_name + ".{compGroup}"
+                    )
+                    + "/Filtered.results.{change_dir}_withNearestGene.txt",
+                    change_dir=change_direction,
+                    compGroup=cf.returnComparisonGroups(sampleSheet),
+                )
+            )
+        return file_list
     else:
-        return([])
+        return []
+
 
 def run_deepTools_qc(fromBAM):
     file_list = []
     if fromBAM:
         file_list = ["deepTools_qc/bamPEFragmentSize/fragmentSize.metric.tsv"]
-        file_list.append([expand("bamCoverage/{sample}.filtered.seq_depth_norm.bw", sample = samples)])
+        file_list.append(
+            [expand("bamCoverage/{sample}.filtered.seq_depth_norm.bw", sample=samples)]
+        )
         if len(samples) <= 20:
-            file_list.append( ["deepTools_qc/plotCoverage/read_coverage.tsv"] )
-        if len(samples)>1 and len(samples)<=20:
-            file_list.append( [
-                "deepTools_qc/plotCorrelation/correlation.pearson.read_coverage.tsv",
-                "deepTools_qc/plotCorrelation/correlation.spearman.read_coverage.tsv",
-                "deepTools_qc/plotPCA/PCA.read_coverage.tsv" ])
-        file_list.append(expand("deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",sample = samples))
-    return (file_list)
+            file_list.append(["deepTools_qc/plotCoverage/read_coverage.tsv"])
+        if len(samples) > 1 and len(samples) <= 20:
+            file_list.append(
+                [
+                    "deepTools_qc/plotCorrelation/correlation.pearson.read_coverage.tsv",
+                    "deepTools_qc/plotCorrelation/correlation.spearman.read_coverage.tsv",
+                    "deepTools_qc/plotPCA/PCA.read_coverage.tsv",
+                ]
+            )
+        file_list.append(
+            expand(
+                "deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",
+                sample=samples,
+            )
+        )
+    return file_list
 
 
 # This needs to be optional
@@ -118,7 +216,7 @@ def run_HMMRATAC():
     file_list = []
     if peakCaller == "HMMRATAC":
         file_list = expand("HMMRATAC/{sample}_peaks.gappedPeak", sample=samples)
-    return (file_list)
+    return file_list
 
 
 def run_genrich():
@@ -126,36 +224,46 @@ def run_genrich():
         file_list = ["Genrich/all_samples.narrowPeak"]
         if sampleSheet:
             if not isMultipleComparison:
-                file_list = ["Genrich/{}.narrowPeak".format(x) for x in genrichDict.keys()]
+                file_list = [
+                    "Genrich/{}.narrowPeak".format(x) for x in genrichDict.keys()
+                ]
             else:
-                #print(genrichDict)
-                unique_group=[]
-                file_list=[]
-                for key,value in genrichDict.items():
+                # print(genrichDict)
+                unique_group = []
+                file_list = []
+                for key, value in genrichDict.items():
                     for x in value.keys():
-                        if zip(key,x) not in unique_group:
-                            unique_group.append(zip(key,x))
-                            file_list.append("Genrich/{}.{}.narrowPeak".format(x,key))
-        file_list.append(expand(short_bams + "{sample}.short.namesorted.bam",sample=samples))
-        return (file_list)
-    return ([])
+                        if zip(key, x) not in unique_group:
+                            unique_group.append(zip(key, x))
+                            file_list.append("Genrich/{}.{}.narrowPeak".format(x, key))
+        file_list.append(
+            expand(short_bams + "{sample}.short.namesorted.bam", sample=samples)
+        )
+        return file_list
+    return []
 
 
 ### execute before workflow starts #############################################
 ################################################################################
 onstart:
     if "verbose" in config and config["verbose"]:
-        print("--- Workflow parameters --------------------------------------------------------")
+        print(
+            "--- Workflow parameters --------------------------------------------------------"
+        )
         print("samples:", samples)
         print("ATAC fragment cutoff: {}-{}".format(minFragmentSize, maxFragmentSize))
         print("-" * 80, "\n")
 
-        print("--- Environment ----------------------------------------------------------------")
-        print("$TMPDIR: ",os.getenv('TMPDIR', ""))
-        print("$HOSTNAME: ",os.getenv('HOSTNAME', ""))
+        print(
+            "--- Environment ----------------------------------------------------------------"
+        )
+        print("$TMPDIR: ", os.getenv("TMPDIR", ""))
+        print("$HOSTNAME: ", os.getenv("HOSTNAME", ""))
         print("-" * 80, "\n")
 
-        print("--- Genome ---------------------------------------------------------------------")
+        print(
+            "--- Genome ---------------------------------------------------------------------"
+        )
         print("Genome:", genome)
         print("Effective genome size:", genome_size)
         print("Genome FASTA:", genome_fasta)
@@ -174,12 +282,19 @@ onstart:
     if sampleSheet:
         cf.copySampleSheet(sampleSheet, workingdir)
 
+
 ### main rule ##################################################################
 ################################################################################
 rule all:
     input:
-        expand(os.path.join(outdir_MACS2, "{sample}.filtered.short.BAM_peaks.xls"), sample = samples),
-        expand(os.path.join(outdir_ATACqc,"{sample}.filtered.BAM_peaks.qc.txt"), sample = samples),
+        expand(
+            os.path.join(outdir_MACS2, "{sample}.filtered.short.BAM_peaks.xls"),
+            sample=samples,
+        ),
+        expand(
+            os.path.join(outdir_ATACqc, "{sample}.filtered.BAM_peaks.qc.txt"),
+            sample=samples,
+        ),
         os.path.join(deeptools_ATAC, "plotFingerprint/plotFingerprint.metrics.txt"),
         ## run deeptools-allelic only if dir "allelic_bams" present and non empty
         run_deepTools_allelic(),
@@ -189,16 +304,24 @@ rule all:
         run_genrich(),
         ## run csaw if asked for
         run_CSAW(),
-        expand("deepTools_ATAC/bamCompare/{sample}.filtered.bw",sample=samples),
+        expand("deepTools_ATAC/bamCompare/{sample}.filtered.bw", sample=samples),
         run_deepTools_qc(fromBAM),
-        expand(os.path.join(short_bams, "{sample}.short.cleaned.bam"),sample=samples),
-        expand(os.path.join(short_bams, "{sample}.short.cleaned.bam.bai"),sample=samples)
+        expand(os.path.join(short_bams, "{sample}.short.cleaned.bam"), sample=samples),
+        expand(
+            os.path.join(short_bams, "{sample}.short.cleaned.bam.bai"), sample=samples
+        ),
+
 
 ### execute after workflow finished ############################################
 ################################################################################
 onsuccess:
     if "verbose" in config and config["verbose"]:
-        print("\n--- The ATACseq open chromatin workflow finished successfully! --------------------------------\n")
+        print(
+            "\n--- The ATACseq open chromatin workflow finished successfully! --------------------------------\n"
+        )
+
 
 onerror:
-    print("\n !!! ERROR in the ATACseq open chromatin workflow! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
+    print(
+        "\n !!! ERROR in the ATACseq open chromatin workflow! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+    )

--- a/snakePipes/workflows/ChIPseq/Snakefile
+++ b/snakePipes/workflows/ChIPseq/Snakefile
@@ -6,46 +6,61 @@ import warnings
 
 ### snakemake_workflows initialization ########################################
 maindir = os.path.dirname(os.path.dirname(workflow.basedir))
-workflow_rscripts=os.path.join(maindir, "shared", "rscripts")
+workflow_rscripts = os.path.join(maindir, "shared", "rscripts")
 
 # load conda ENVs (path is relative to "shared/rules" directory)
 globals().update(cf.set_env_yamls())
 
 # load config file
-globals().update(cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"]))
+globals().update(
+    cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"])
+)
 # load organism-specific data, i.e. genome indices, annotation, etc.
 globals().update(cf.load_organism_data(genome, maindir, config["verbose"]))
 # return the pipeline version in the log
 cf.get_version()
 
+
 # do workflow specific stuff now
 include: os.path.join(workflow.basedir, "internals.snakefile")
-
 ### include modules of other snakefiles ########################################
 ################################################################################
 # deeptools cmds
-include: os.path.join(maindir, "shared", "tools" , "deeptools_cmds.snakefile")
+include: os.path.join(maindir, "shared", "tools", "deeptools_cmds.snakefile")
+
+
 # fromBAM
 if fromBAM:
+
     include: os.path.join(maindir, "shared", "rules", "LinkBam.snakefile")
+
     if not useSpikeInForNorm:
+
         include: os.path.join(maindir, "shared", "rules", "deepTools_qc.snakefile")
+
     else:
+
         include: os.path.join(maindir, "shared", "rules", "split_bam_ops_DNA_spikein.snakefile")
 
+
 if useSpikeInForNorm:
-        #include: os.path.join(maindir, "shared", "rules", "split_bam_ops_ChIP_spikein.snakefile")
-        include: os.path.join(maindir, "shared", "rules", "deepTools_ChIP_spikein.snakefile")
-        include: os.path.join(maindir, "shared", "rules", "ChIP_peak_calling_spikein.snakefile")
-        include: os.path.join(maindir, "shared", "rules", "filterGTF_spikein.snakefile")
+
+    # include: os.path.join(maindir, "shared", "rules", "split_bam_ops_ChIP_spikein.snakefile")
+    include: os.path.join(maindir, "shared", "rules", "deepTools_ChIP_spikein.snakefile")
+    include: os.path.join(maindir, "shared", "rules", "ChIP_peak_calling_spikein.snakefile")
+    include: os.path.join(maindir, "shared", "rules", "filterGTF_spikein.snakefile")
+
 else:
+
     # deepTools ChIP
     include: os.path.join(maindir, "shared", "rules", "deepTools_ChIP.snakefile")
     # MACS2, MACS2 peak QC, and Genrich
     include: os.path.join(maindir, "shared", "rules", "ChIP_peak_calling.snakefile")
 
+
 # QC report for all samples
 if not fromBAM and not useSpikeInForNorm:
+
     include: os.path.join(maindir, "shared", "rules", "ChiP-seq_qc_report.snakefile")
 
 
@@ -54,193 +69,450 @@ if not fromBAM and not useSpikeInForNorm:
 
 # histoneHMM (if mode is not allele-specific)
 if not allele_info:
+
     include: os.path.join(maindir, "shared", "rules", "histoneHMM.snakefile")
+
 else:
+
     include: os.path.join(maindir, "shared", "rules", "deepTools_ChIP_allelic.snakefile")
+
 
 # CSAW for differential binding (if sampleinfo specified)
 if sampleSheet and cf.check_replicates(sampleSheet):
     if not isMultipleComparison:
+
         include: os.path.join(maindir, "shared", "rules", "CSAW.singleComp.snakefile")
         include: os.path.join(maindir, "shared", "rules", "nearestGene.singleComp.snakefile")
+
     else:
+
         include: os.path.join(maindir, "shared", "rules", "CSAW.multiComp.snakefile")
         include: os.path.join(maindir, "shared", "rules", "nearestGene.multiComp.snakefile")
     include: os.path.join(maindir, "shared", "rules", "filterGTF.snakefile")
 
-def run_histoneHMM(allele_info,peakCaller): # TODO what is a good practice for broad peaks of cutntag?
-    if not allele_info and peakCaller=="histoneHMM":
+
+def run_histoneHMM(
+    allele_info, peakCaller
+):  # TODO what is a good practice for broad peaks of cutntag?
+    if not allele_info and peakCaller == "histoneHMM":
         ## run histoneHMM broad enrichment calling only for samples annotated as *broad*
-        file_list = expand("histoneHMM/{sample}.filtered.histoneHMM-regions.gff.gz", sample=broad_samples)
-        file_list.append(expand("histoneHMM/{sample}_avgp0.5.bed", sample=broad_samples))
+        file_list = expand(
+            "histoneHMM/{sample}.filtered.histoneHMM-regions.gff.gz",
+            sample=broad_samples,
+        )
+        file_list.append(
+            expand("histoneHMM/{sample}_avgp0.5.bed", sample=broad_samples)
+        )
         file_list.append("histoneHMM_chipqc/sessionInfo.txt")
     else:
         file_list = []
-    return(file_list)
+    return file_list
 
-def run_deepTools_qc(fromBAM,useSpikeInForNorm):
+
+def run_deepTools_qc(fromBAM, useSpikeInForNorm):
     if fromBAM:
         if not useSpikeInForNorm:
             file_list = ["deepTools_qc/bamPEFragmentSize/fragmentSize.metric.tsv"]
-            file_list.append([expand("bamCoverage/{sample}.filtered.seq_depth_norm.bw", sample = samples)])
+            file_list.append(
+                [
+                    expand(
+                        "bamCoverage/{sample}.filtered.seq_depth_norm.bw",
+                        sample=samples,
+                    )
+                ]
+            )
             if len(samples) <= 20:
-                file_list.append( ["deepTools_qc/plotCoverage/read_coverage.tsv"] )
-            if len(samples)>1 and len(samples)<=20:
-                file_list.append( [
-                    "deepTools_qc/plotCorrelation/correlation.pearson.read_coverage.tsv",
-                    "deepTools_qc/plotCorrelation/correlation.spearman.read_coverage.tsv",
-                    "deepTools_qc/plotPCA/PCA.read_coverage.tsv" ])
-            file_list.append(expand("deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",sample = samples))
+                file_list.append(["deepTools_qc/plotCoverage/read_coverage.tsv"])
+            if len(samples) > 1 and len(samples) <= 20:
+                file_list.append(
+                    [
+                        "deepTools_qc/plotCorrelation/correlation.pearson.read_coverage.tsv",
+                        "deepTools_qc/plotCorrelation/correlation.spearman.read_coverage.tsv",
+                        "deepTools_qc/plotPCA/PCA.read_coverage.tsv",
+                    ]
+                )
+            file_list.append(
+                expand(
+                    "deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",
+                    sample=samples,
+                )
+            )
         else:
-            file_list=expand("split_deepTools_qc/bamPEFragmentSize/host.fragmentSize.metric.tsv")
-            file_list.append(expand("bamCoverage/{sample}.host_scaled.BYspikein.bw",sample=samples))
+            file_list = expand(
+                "split_deepTools_qc/bamPEFragmentSize/host.fragmentSize.metric.tsv"
+            )
+            file_list.append(
+                expand("bamCoverage/{sample}.host_scaled.BYspikein.bw", sample=samples)
+            )
     else:
         file_list = []
-    return(file_list)
+    return file_list
+
 
 def run_deepTools_ChIP():
     file_list = []
-    file_list.append(["deepTools_ChIP/plotFingerprint/plotFingerprint.metrics.txt"]) if not useSpikeInForNorm \
-                    else file_list.append(["split_deepTools_ChIP/plotFingerprint/plotFingerprint.metrics.txt"])
+    (
+        file_list.append(["deepTools_ChIP/plotFingerprint/plotFingerprint.metrics.txt"])
+        if not useSpikeInForNorm
+        else file_list.append(
+            ["split_deepTools_ChIP/plotFingerprint/plotFingerprint.metrics.txt"]
+        )
+    )
     if chip_samples_w_ctrl:
         for chip_sample in chip_samples_w_ctrl:
             control_name = get_control_name(chip_sample)
             if not useSpikeInForNorm:
                 # get bigwigtype
                 if bigWigType == "subtract" or bigWigType == "both":
-                    file_list.append(["deepTools_ChIP/bamCompare/"+chip_sample+".filtered.subtract."+control_name+".bw"])
+                    file_list.append(
+                        [
+                            "deepTools_ChIP/bamCompare/"
+                            + chip_sample
+                            + ".filtered.subtract."
+                            + control_name
+                            + ".bw"
+                        ]
+                    )
                 if bigWigType == "log2ratio" or bigWigType == "both":
-                    file_list.append(["deepTools_ChIP/bamCompare/"+chip_sample+".filtered.log2ratio.over_"+control_name+".bw"])
+                    file_list.append(
+                        [
+                            "deepTools_ChIP/bamCompare/"
+                            + chip_sample
+                            + ".filtered.log2ratio.over_"
+                            + control_name
+                            + ".bw"
+                        ]
+                    )
             else:
                 # get bigwigtype
                 if bigWigType == "subtract" or bigWigType == "both":
-                    file_list.append(expand("split_deepTools_ChIP/bamCompare/"+chip_sample+".subtract."+control_name+".scaledBYspikein.bw"))
+                    file_list.append(
+                        expand(
+                            "split_deepTools_ChIP/bamCompare/"
+                            + chip_sample
+                            + ".subtract."
+                            + control_name
+                            + ".scaledBYspikein.bw"
+                        )
+                    )
                 if bigWigType == "log2ratio" or bigWigType == "both":
-                    file_list.append(expand("split_deepTools_ChIP/bamCompare/"+chip_sample+".log2ratio.over_"+control_name+".scaledBYspikein.bw"))
-    return(file_list)
+                    file_list.append(
+                        expand(
+                            "split_deepTools_ChIP/bamCompare/"
+                            + chip_sample
+                            + ".log2ratio.over_"
+                            + control_name
+                            + ".scaledBYspikein.bw"
+                        )
+                    )
+    return file_list
+
 
 def run_deepTools_allelic():
     file_list = []
-    if os.path.isdir('allelic_bams') and os.listdir('allelic_bams') != []:
+    if os.path.isdir("allelic_bams") and os.listdir("allelic_bams") != []:
         for chip_sample in chip_samples_w_ctrl:
             control_name = get_control_name(chip_sample)
             if not useSpikeInForNorm:
-                file_list.append([
-                "deepTools_ChIP/bamCompare/allele_specific/"+chip_sample+".genome1.log2ratio.over_"+control_name+".bw",
-                "deepTools_ChIP/bamCompare/allele_specific/"+chip_sample+".genome2.log2ratio.over_"+control_name+".bw",
-                ])
+                file_list.append(
+                    [
+                        "deepTools_ChIP/bamCompare/allele_specific/"
+                        + chip_sample
+                        + ".genome1.log2ratio.over_"
+                        + control_name
+                        + ".bw",
+                        "deepTools_ChIP/bamCompare/allele_specific/"
+                        + chip_sample
+                        + ".genome2.log2ratio.over_"
+                        + control_name
+                        + ".bw",
+                    ]
+                )
             else:
-                file_list.append([
-                "deepTools_ChIP/bamCompare/allele_specific/"+chip_sample+".genome1.log2ratio.over_"+control_name+".scaledBYspikein.bw",
-                "deepTools_ChIP/bamCompare/allele_specific/"+chip_sample+".genome2.log2ratio.over_"+control_name+"scaledBYspikein.bw",
-                ])
-        file_list.append( [
-        "deepTools_ChIP/plotEnrichment/plotEnrichment.gene_features_allelic.png",
-        "deepTools_ChIP/plotEnrichment/plotEnrichment.gene_features_allelic.tsv",
-        "deepTools_ChIP/plotFingerprint/plotFingerprint.metrics_allelic.txt"
-         ] )
+                file_list.append(
+                    [
+                        "deepTools_ChIP/bamCompare/allele_specific/"
+                        + chip_sample
+                        + ".genome1.log2ratio.over_"
+                        + control_name
+                        + ".scaledBYspikein.bw",
+                        "deepTools_ChIP/bamCompare/allele_specific/"
+                        + chip_sample
+                        + ".genome2.log2ratio.over_"
+                        + control_name
+                        + "scaledBYspikein.bw",
+                    ]
+                )
+        file_list.append(
+            [
+                "deepTools_ChIP/plotEnrichment/plotEnrichment.gene_features_allelic.png",
+                "deepTools_ChIP/plotEnrichment/plotEnrichment.gene_features_allelic.tsv",
+                "deepTools_ChIP/plotFingerprint/plotFingerprint.metrics_allelic.txt",
+            ]
+        )
         if useSpikeInForNorm:
             for chip_sample in chip_samples_w_ctrl:
                 control_name = get_control_name(chip_sample)
-                file_list.append([
-                "deepTools_ChIP/bamCompare/allele_specific/"+chip_sample+".genome1.log2ratio.over_"+control_name+".scaledBYspikein.bw",
-                "deepTools_ChIP/bamCompare/allele_specific/"+chip_sample+".genome2.log2ratio.over_"+control_name+".scaledBYspikein.bw"
-    ])
-    return(file_list)
+                file_list.append(
+                    [
+                        "deepTools_ChIP/bamCompare/allele_specific/"
+                        + chip_sample
+                        + ".genome1.log2ratio.over_"
+                        + control_name
+                        + ".scaledBYspikein.bw",
+                        "deepTools_ChIP/bamCompare/allele_specific/"
+                        + chip_sample
+                        + ".genome2.log2ratio.over_"
+                        + control_name
+                        + ".scaledBYspikein.bw",
+                    ]
+                )
+    return file_list
+
 
 def run_CSAW():
     if sampleSheet and cf.check_replicates(sampleSheet):
         if not isMultipleComparison:
-            file_list=["CSAW_{}_{}/CSAW.session_info.txt".format(peakCaller, sample_name),"CSAW_{}_{}/Full.results.bed".format(peakCaller, sample_name)]
-            if not allele_info :
-                file_list.append(["Annotation/genes.filtered.symbol","Annotation/genes.filtered.t2g","CSAW_{}_{}/CSAW.Stats_report.html".format(peakCaller, sample_name)])
-                file_list.append([os.path.join("CSAW_{}_{}".format(peakCaller, sample_name), x) for x in list(itertools.chain.from_iterable([expand("CSAW.{change_dir}.cov.matrix",change_dir=change_direction),expand("CSAW.{change_dir}.cov.heatmap.png",change_dir=change_direction)]))])
-                file_list.append([os.path.join("AnnotatedResults_{}_{}".format(peakCaller,sample_name), x) for x in list(itertools.chain.from_iterable([expand("Filtered.results.{change_dir}_withNearestGene.txt",change_dir=change_direction)]))])
+            file_list = [
+                "CSAW_{}_{}/CSAW.session_info.txt".format(peakCaller, sample_name),
+                "CSAW_{}_{}/Full.results.bed".format(peakCaller, sample_name),
+            ]
+            if not allele_info:
+                file_list.append(
+                    [
+                        "Annotation/genes.filtered.symbol",
+                        "Annotation/genes.filtered.t2g",
+                        "CSAW_{}_{}/CSAW.Stats_report.html".format(
+                            peakCaller, sample_name
+                        ),
+                    ]
+                )
+                file_list.append(
+                    [
+                        os.path.join("CSAW_{}_{}".format(peakCaller, sample_name), x)
+                        for x in list(
+                            itertools.chain.from_iterable(
+                                [
+                                    expand(
+                                        "CSAW.{change_dir}.cov.matrix",
+                                        change_dir=change_direction,
+                                    ),
+                                    expand(
+                                        "CSAW.{change_dir}.cov.heatmap.png",
+                                        change_dir=change_direction,
+                                    ),
+                                ]
+                            )
+                        )
+                    ]
+                )
+                file_list.append(
+                    [
+                        os.path.join(
+                            "AnnotatedResults_{}_{}".format(peakCaller, sample_name), x
+                        )
+                        for x in list(
+                            itertools.chain.from_iterable(
+                                [
+                                    expand(
+                                        "Filtered.results.{change_dir}_withNearestGene.txt",
+                                        change_dir=change_direction,
+                                    )
+                                ]
+                            )
+                        )
+                    ]
+                )
                 if chip_samples_w_ctrl and not useSpikeInForNorm:
-                    file_list.append([os.path.join("CSAW_{}_{}".format(peakCaller, sample_name), x) for x in list(itertools.chain.from_iterable([expand("CSAW.{change_dir}.log2r.matrix",change_dir=change_direction),expand("CSAW.{change_dir}.log2r.heatmap.png",change_dir=change_direction)]))])
+                    file_list.append(
+                        [
+                            os.path.join(
+                                "CSAW_{}_{}".format(peakCaller, sample_name), x
+                            )
+                            for x in list(
+                                itertools.chain.from_iterable(
+                                    [
+                                        expand(
+                                            "CSAW.{change_dir}.log2r.matrix",
+                                            change_dir=change_direction,
+                                        ),
+                                        expand(
+                                            "CSAW.{change_dir}.log2r.heatmap.png",
+                                            change_dir=change_direction,
+                                        ),
+                                    ]
+                                )
+                            )
+                        ]
+                    )
         else:
-            file_list=expand("CSAW_{}_{}/CSAW.session_info.txt".format(peakCaller, sample_name + ".{compGroup}"),compGroup=cf.returnComparisonGroups(sampleSheet))
-            file_list.append(expand("CSAW_{}_{}/Full.results.bed".format(peakCaller, sample_name + ".{compGroup}"),compGroup=cf.returnComparisonGroups(sampleSheet)))
-            if not allele_info :
-                file_list.append(["Annotation/genes.filtered.symbol","Annotation/genes.filtered.t2g",expand("CSAW_{}_{}/CSAW.Stats_report.html".format(peakCaller, sample_name + ".{compGroup}"),compGroup=cf.returnComparisonGroups(sampleSheet))])
-                file_list.append([expand("CSAW_{}_{}".format(peakCaller, sample_name + ".{compGroup}") + "/CSAW.{change_dir}.cov.matrix",change_dir=change_direction,compGroup=cf.returnComparisonGroups(sampleSheet)),
-                  expand("CSAW_{}_{}".format(peakCaller, sample_name + ".{compGroup}") +"/CSAW.{change_dir}.cov.heatmap.png",change_dir=change_direction,compGroup=cf.returnComparisonGroups(sampleSheet)
-                  )])
-                file_list.append(expand("AnnotatedResults_{}_{}".format(peakCaller,sample_name + ".{compGroup}") + "/Filtered.results.{change_dir}_withNearestGene.txt",change_dir=change_direction, compGroup=cf.returnComparisonGroups(sampleSheet)))
+            file_list = expand(
+                "CSAW_{}_{}/CSAW.session_info.txt".format(
+                    peakCaller, sample_name + ".{compGroup}"
+                ),
+                compGroup=cf.returnComparisonGroups(sampleSheet),
+            )
+            file_list.append(
+                expand(
+                    "CSAW_{}_{}/Full.results.bed".format(
+                        peakCaller, sample_name + ".{compGroup}"
+                    ),
+                    compGroup=cf.returnComparisonGroups(sampleSheet),
+                )
+            )
+            if not allele_info:
+                file_list.append(
+                    [
+                        "Annotation/genes.filtered.symbol",
+                        "Annotation/genes.filtered.t2g",
+                        expand(
+                            "CSAW_{}_{}/CSAW.Stats_report.html".format(
+                                peakCaller, sample_name + ".{compGroup}"
+                            ),
+                            compGroup=cf.returnComparisonGroups(sampleSheet),
+                        ),
+                    ]
+                )
+                file_list.append(
+                    [
+                        expand(
+                            "CSAW_{}_{}".format(
+                                peakCaller, sample_name + ".{compGroup}"
+                            )
+                            + "/CSAW.{change_dir}.cov.matrix",
+                            change_dir=change_direction,
+                            compGroup=cf.returnComparisonGroups(sampleSheet),
+                        ),
+                        expand(
+                            "CSAW_{}_{}".format(
+                                peakCaller, sample_name + ".{compGroup}"
+                            )
+                            + "/CSAW.{change_dir}.cov.heatmap.png",
+                            change_dir=change_direction,
+                            compGroup=cf.returnComparisonGroups(sampleSheet),
+                        ),
+                    ]
+                )
+                file_list.append(
+                    expand(
+                        "AnnotatedResults_{}_{}".format(
+                            peakCaller, sample_name + ".{compGroup}"
+                        )
+                        + "/Filtered.results.{change_dir}_withNearestGene.txt",
+                        change_dir=change_direction,
+                        compGroup=cf.returnComparisonGroups(sampleSheet),
+                    )
+                )
                 if chip_samples_w_ctrl and not useSpikeInForNorm:
-                    file_list.append([expand("CSAW_{}_{}".format(peakCaller, sample_name + ".{compGroup}") + "/CSAW.{change_dir}.log2r.matrix",change_dir=change_direction,compGroup=cf.returnComparisonGroups(sampleSheet)),
-                      expand("CSAW_{}_{}".format(peakCaller, sample_name + ".{compGroup}") + "/CSAW.{change_dir}.log2r.heatmap.png",change_dir=change_direction,compGroup=cf.returnComparisonGroups(sampleSheet))
-                      ])
-        return( file_list )
+                    file_list.append(
+                        [
+                            expand(
+                                "CSAW_{}_{}".format(
+                                    peakCaller, sample_name + ".{compGroup}"
+                                )
+                                + "/CSAW.{change_dir}.log2r.matrix",
+                                change_dir=change_direction,
+                                compGroup=cf.returnComparisonGroups(sampleSheet),
+                            ),
+                            expand(
+                                "CSAW_{}_{}".format(
+                                    peakCaller, sample_name + ".{compGroup}"
+                                )
+                                + "/CSAW.{change_dir}.log2r.heatmap.png",
+                                change_dir=change_direction,
+                                compGroup=cf.returnComparisonGroups(sampleSheet),
+                            ),
+                        ]
+                    )
+        return file_list
     else:
-        return([])
+        return []
 
 
 def run_genrich():
-    if (peakCaller == "Genrich"):
+    if peakCaller == "Genrich":
         file_list = ["Genrich/all_samples.narrowPeak"]
         if sampleSheet:
             if not isMultipleComparison:
-                file_list = ["Genrich/{}.narrowPeak".format(x) for x in genrichDict.keys()]
+                file_list = [
+                    "Genrich/{}.narrowPeak".format(x) for x in genrichDict.keys()
+                ]
             else:
-                #print(genrichDict)
-                unique_group=[]
-                file_list=[]
-                for key,value in genrichDict.items():
+                # print(genrichDict)
+                unique_group = []
+                file_list = []
+                for key, value in genrichDict.items():
                     for x in value.keys():
-                        if zip(key,x) not in unique_group:
-                            unique_group.append(zip(key,x))
-                            file_list.append("Genrich/{}.{}.narrowPeak".format(x,key))
-        return (file_list)
+                        if zip(key, x) not in unique_group:
+                            unique_group.append(zip(key, x))
+                            file_list.append("Genrich/{}.{}.narrowPeak".format(x, key))
+        return file_list
     else:
-        return ([])
+        return []
 
 
 def run_macs2():
     if peakCaller == "MACS2":
         if useSpikeInForNorm:
-            file_list = expand("MACS2/{chip_sample}_host.BAM_peaks.xls", chip_sample = chip_samples)
+            file_list = expand(
+                "MACS2/{chip_sample}_host.BAM_peaks.xls", chip_sample=chip_samples
+            )
         else:
-            file_list = expand("MACS2/{chip_sample}.filtered.BAM_peaks.xls", chip_sample = chip_samples)
-        return (file_list)
-    return ([])
+            file_list = expand(
+                "MACS2/{chip_sample}.filtered.BAM_peaks.xls", chip_sample=chip_samples
+            )
+        return file_list
+    return []
 
 
 def run_seacr():
-    if (peakCaller == "SEACR"):
+    if peakCaller == "SEACR":
         if useSpikeInForNorm:
-            file_list = expand("SEACR/{chip_sample}_host.{mode}.bed", chip_sample = chip_samples,mode=["stringent"])
+            file_list = expand(
+                "SEACR/{chip_sample}_host.{mode}.bed",
+                chip_sample=chip_samples,
+                mode=["stringent"],
+            )
         else:
-            file_list = expand("SEACR/{chip_sample}.filtered.{mode}.bed", chip_sample = chip_samples,mode=["stringent"])
-        return (file_list)
-    return ([])
+            file_list = expand(
+                "SEACR/{chip_sample}.filtered.{mode}.bed",
+                chip_sample=chip_samples,
+                mode=["stringent"],
+            )
+        return file_list
+    return []
 
 
 def run_chipqc():
-    file_list=[]
+    file_list = []
     if not peakCaller == "Genrich" and not externalBed:
         file_list = "{}_chipqc/sessionInfo.txt".format(peakCaller)
-    return(file_list)
-
+    return file_list
 
 
 ### execute before workflow starts #############################################
 ################################################################################
 onstart:
     if "verbose" in config and config["verbose"]:
-        print("--- Workflow parameter ---------------------------------------------------------")
+        print(
+            "--- Workflow parameter ---------------------------------------------------------"
+        )
         print("control samples:", control_samples)
         print("ChIP samples w ctrl:", chip_samples_w_ctrl)
         print("ChIP samples wo ctrl:", chip_samples_wo_ctrl)
         print("paired:", pairedEnd)
         print("-" * 80, "\n")
 
-        print("--- Environment ----------------------------------------------------------------")
-        print("$TMPDIR: ",os.getenv('TMPDIR', ""))
-        print("$HOSTNAME: ",os.getenv('HOSTNAME', ""))
+        print(
+            "--- Environment ----------------------------------------------------------------"
+        )
+        print("$TMPDIR: ", os.getenv("TMPDIR", ""))
+        print("$HOSTNAME: ", os.getenv("HOSTNAME", ""))
         print("-" * 80, "\n")
 
-        print("--- Genome ---------------------------------------------------------------------")
+        print(
+            "--- Genome ---------------------------------------------------------------------"
+        )
         print("Genome:", genome)
         print("Effective genome size:", genome_size)
         print("Genome FASTA:", genome_fasta)
@@ -264,28 +536,29 @@ onstart:
 ################################################################################
 rule all:
     input:
-        run_deepTools_qc(fromBAM,useSpikeInForNorm),
+        run_deepTools_qc(fromBAM, useSpikeInForNorm),
         run_deepTools_ChIP(),
         run_macs2(),
         run_genrich(),
         run_seacr(),
         # run histoneHMM if allelic_bams are absent (since it gives index error without allele_specific index)
-        run_histoneHMM(allele_info,peakCaller),
+        run_histoneHMM(allele_info, peakCaller),
         ## run deeptools-allelic only if dir "allelic_bams" present and non empty
         run_deepTools_allelic(),
         ## run csaw if asked for
         run_CSAW(),
         "QC_report/QC_report_all.tsv" if not fromBAM and not useSpikeInForNorm else [],
-        run_chipqc()
+        run_chipqc(),
 
 
 ### execute after workflow finished ############################################
 ################################################################################
 onsuccess:
     if "verbose" in config and config["verbose"]:
-        print("\n--- ChIPseq workflow finished successfully! -----------------------------------\n")
+        print(
+            "\n--- ChIPseq workflow finished successfully! -----------------------------------\n"
+        )
+
 
 onerror:
     print("\n !!! ERROR in ChIPseq workflow! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
-
-

--- a/snakePipes/workflows/DNAmapping/Snakefile
+++ b/snakePipes/workflows/DNAmapping/Snakefile
@@ -8,11 +8,14 @@ maindir = os.path.dirname(os.path.dirname(workflow.basedir))
 globals().update(cf.set_env_yamls())
 
 # load config file
-globals().update(cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"]))
+globals().update(
+    cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"])
+)
 # load organism-specific data, i.e. genome indices, annotation, etc.
 globals().update(cf.load_organism_data(genome, maindir, config["verbose"]))
 # return the pipeline version in the log
 cf.get_version()
+
 
 # do workflow specific stuff now
 include: os.path.join(workflow.basedir, "internals.snakefile")
@@ -21,182 +24,274 @@ include: os.path.join(workflow.basedir, "internals.snakefile")
 ### include modules of other snakefiles ########################################
 ################################################################################
 
+
 # FASTQ: either downsample FASTQ files or create symlinks to input files
 include: os.path.join(maindir, "shared", "rules", "FASTQ.snakefile")
 
+
 # FastQC
 if fastqc:
+
     include: os.path.join(maindir, "shared", "rules", "FastQC.snakefile")
+
 
 # trimming
 if trim:
+
     include: os.path.join(maindir, "shared", "rules", "trimming.snakefile")
+
 
 # BAM filtering
 include: os.path.join(maindir, "shared", "rules", "bam_filtering.snakefile")
-
-#umi_tools extract and dedup
+# umi_tools extract and dedup
 include: os.path.join(maindir, "shared", "rules", "umi_tools.snakefile")
-#Sambamba Markdup
+# Sambamba Markdup
 include: os.path.join(maindir, "shared", "rules", "sambamba.snakefile")
-
 # deeptools cmds
-include: os.path.join(maindir, "shared", "tools" , "deeptools_cmds.snakefile")
-
+include: os.path.join(maindir, "shared", "tools", "deeptools_cmds.snakefile")
 # deepTools QC
 include: os.path.join(maindir, "shared", "rules", "deepTools_qc.snakefile")
 
+
 if useSpikeInForNorm:
+
     include: os.path.join(maindir, "shared", "rules", "split_bam_ops_DNA_spikein.snakefile")
+
 
 ## MultiQC
 include: os.path.join(maindir, "shared", "rules", "multiQC.snakefile")
+
 
 ## Allele-specific JOBs
 if "allelic-mapping" in mode:
     genome_alias = os.path.splitext(os.path.basename(genome))[0]
     # Updated global vars if mode = "allelic-mapping"
-    if allele_mode == 'create_and_map':
-        bowtie2_index_allelic = 'snp_genome/bowtie2_Nmasked/Genome.1.bt2'
+    if allele_mode == "create_and_map":
+        bowtie2_index_allelic = "snp_genome/bowtie2_Nmasked/Genome.1.bt2"
         if len(strains) == 1:
-            allele_hybrid = 'single'
-            SNPFile = "snp_genome/all_SNPs_" + strains[0] + "_" + genome_alias + ".txt.gz"
+            allele_hybrid = "single"
+            SNPFile = (
+                "snp_genome/all_SNPs_" + strains[0] + "_" + genome_alias + ".txt.gz"
+            )
         elif len(strains) == 2:
-            allele_hybrid = 'dual'
-            SNPFile = "snp_genome/all_" + strains[1] + "_SNPs_" + strains[0] + "_reference.based_on_" + genome_alias + ".txt"
+            allele_hybrid = "dual"
+            SNPFile = (
+                "snp_genome/all_"
+                + strains[1]
+                + "_SNPs_"
+                + strains[0]
+                + "_reference.based_on_"
+                + genome_alias
+                + ".txt"
+            )
 
         include: os.path.join(maindir, "shared", "rules", "masked_genomeIndex.snakefile")
-    elif allele_mode == 'map_only':
+
+    elif allele_mode == "map_only":
         bowtie2_index_allelic = NMaskedIndex
         SNPFile = SNPfile
-    ## mapping rules
+
+        ## mapping rules
     include: os.path.join(maindir, "shared", "rules", "Bowtie2_allelic.snakefile")
     ## SNPsplit
     include: os.path.join(maindir, "shared", "rules", "SNPsplit.snakefile")
     # deepTools QC
     include: os.path.join(maindir, "shared", "rules", "deepTools_qc_allelic.snakefile")
+
 else:
     if aligner == "Bowtie2":
+
         # Bowtie2 mapping, duplicate marking, BAM filtering and indexing
         include: os.path.join(maindir, "shared", "rules", "Bowtie2.snakefile")
+
     elif aligner == "bwa":
+
         include: os.path.join(maindir, "shared", "rules", "bwa.snakefile")
+
     elif aligner == "bwa-mem2":
+
         include: os.path.join(maindir, "shared", "rules", "bwa-mem2.snakefile")
 
+
 if "allelic-whatshap" in mode:
+
     include: os.path.join(maindir, "shared", "rules", "whatshap.snakefile")
     include: os.path.join(maindir, "shared", "rules", "deepTools_qc_allelic.snakefile")
+
     if useSpikeInForNorm:
+
         include: os.path.join(maindir, "shared", "rules", "deepTools_qc_allelic_spikein.snakefile")
+
 
 ### conditional/optional rules #################################################
 ################################################################################
 
+
 def run_FastQC(fastqc):
     if fastqc:
-        return( expand("FastQC/{sample}{read}_fastqc.html", sample = samples, read = reads[:idxRange]) )
+        return expand(
+            "FastQC/{sample}{read}_fastqc.html", sample=samples, read=reads[:idxRange]
+        )
     else:
-        return([])
+        return []
+
 
 def run_Trimming(trim, fastqc):
     if trim and fastqc:
-        return( expand(fastq_dir+"/{sample}{read}.fastq.gz", sample = samples, read = reads[:idxRange]) +
-                expand("FastQC_trimmed/{sample}{read}_fastqc.html", sample = samples, read = reads[:idxRange]) )
+        return expand(
+            fastq_dir + "/{sample}{read}.fastq.gz", sample=samples, read=reads[:idxRange]
+        ) + expand(
+            "FastQC_trimmed/{sample}{read}_fastqc.html",
+            sample=samples,
+            read=reads[:idxRange],
+        )
     elif trim:
-        return( expand(fastq_dir+"/{sample}{read}.fastq.gz", sample = samples, read = reads[:idxRange]) )
+        return expand(
+            fastq_dir + "/{sample}{read}.fastq.gz", sample=samples, read=reads[:idxRange]
+        )
     else:
-        return([])
+        return []
+
 
 def run_computeGCBias(GCBias):
     file_list = []
     if GCBias:
         if not downsample:
-            file_list = expand("deepTools_qc/computeGCBias/{sample}.filtered.GCBias.png", sample = samples)
-    return(file_list)
+            file_list = expand(
+                "deepTools_qc/computeGCBias/{sample}.filtered.GCBias.png", sample=samples
+            )
+    return file_list
+
 
 def run_splitBam_ops():
     if useSpikeInForNorm:
-        file_list = expand("split_bam/{sample}_{part}.bam",sample=samples,part=part)
+        file_list = expand("split_bam/{sample}_{part}.bam", sample=samples, part=part)
         file_list.append(
-            [expand("split_deepTools_qc/multiBamSummary/{part}.scaling_factors.txt",part=part),
-            expand("bamCoverage/{sample}.host_scaled.BY{part}.bw",sample=samples,part=part),
-            "split_deepTools_qc/bamPEFragmentSize/host.fragmentSize.metric.tsv"]
-            )
+            [
+                expand(
+                    "split_deepTools_qc/multiBamSummary/{part}.scaling_factors.txt",
+                    part=part,
+                ),
+                expand(
+                    "bamCoverage/{sample}.host_scaled.BY{part}.bw",
+                    sample=samples,
+                    part=part,
+                ),
+                "split_deepTools_qc/bamPEFragmentSize/host.fragmentSize.metric.tsv",
+            ]
+        )
         if "allelic-whatshap" in mode:
-            allele_suffix = ['genome1', 'genome2']
+            allele_suffix = ["genome1", "genome2"]
             file_list.append(
-                [expand("bamCoverage/allele_specific/{sample}.{suffix}.host_scaled.BYspikein.bw",sample=samples,suffix=allele_suffix)]
-)
+                [
+                    expand(
+                        "bamCoverage/allele_specific/{sample}.{suffix}.host_scaled.BYspikein.bw",
+                        sample=samples,
+                        suffix=allele_suffix,
+                    )
+                ]
+            )
     else:
         file_list = []
-    return(file_list)
+    return file_list
+
 
 def run_deepTools_qc():
     file_list = ["deepTools_qc/bamPEFragmentSize/fragmentSize.metric.tsv"]
     if len(samples) <= 20:
-        file_list.append( ["deepTools_qc/plotCoverage/read_coverage.tsv"] )
-    if len(samples)>1 and len(samples)<=20:
-        file_list.append( [
-            "deepTools_qc/plotCorrelation/correlation.pearson.read_coverage.tsv",
-            "deepTools_qc/plotCorrelation/correlation.spearman.read_coverage.tsv",
-            "deepTools_qc/plotPCA/PCA.read_coverage.tsv" ])
-        if 'allelic-mapping' in mode or 'allelic-whatshap' in mode:
-            file_list.append( [
-                "deepTools_qc/plotCorrelation/correlation.pearson.read_coverage_allelic.tsv",
-                "deepTools_qc/plotCorrelation/correlation.spearman.read_coverage_allelic.tsv",
-                "deepTools_qc/plotPCA/PCA.read_coverage_allelic.tsv" ] )
-    file_list.append(expand("deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",sample = samples))
-    return (file_list)
+        file_list.append(["deepTools_qc/plotCoverage/read_coverage.tsv"])
+    if len(samples) > 1 and len(samples) <= 20:
+        file_list.append(
+            [
+                "deepTools_qc/plotCorrelation/correlation.pearson.read_coverage.tsv",
+                "deepTools_qc/plotCorrelation/correlation.spearman.read_coverage.tsv",
+                "deepTools_qc/plotPCA/PCA.read_coverage.tsv",
+            ]
+        )
+        if "allelic-mapping" in mode or "allelic-whatshap" in mode:
+            file_list.append(
+                [
+                    "deepTools_qc/plotCorrelation/correlation.pearson.read_coverage_allelic.tsv",
+                    "deepTools_qc/plotCorrelation/correlation.spearman.read_coverage_allelic.tsv",
+                    "deepTools_qc/plotPCA/PCA.read_coverage_allelic.tsv",
+                ]
+            )
+    file_list.append(
+        expand(
+            "deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",
+            sample=samples,
+        )
+    )
+    return file_list
+
 
 # allele specific
 def make_nmasked_genome():
-    if allele_mode == 'create_and_map':
-        genome1 = "snp_genome/" + strains[0] + '_SNP_filtering_report.txt'
-        file_list = [
-                genome1,
-                SNPFile,
-                bowtie2_index_allelic
-                ]
-        return(file_list)
+    if allele_mode == "create_and_map":
+        genome1 = "snp_genome/" + strains[0] + "_SNP_filtering_report.txt"
+        file_list = [genome1, SNPFile, bowtie2_index_allelic]
+        return file_list
     else:
-        return([])
+        return []
+
 
 def run_allelesp_mapping():
     if "allelic-mapping" in mode:
-        allele_suffix = ['allele_flagged', 'genome1', 'genome2', 'unassigned']
+        allele_suffix = ["allele_flagged", "genome1", "genome2", "unassigned"]
         file_list = [
-        expand("allelic_bams/{sample}.{suffix}.sorted.bam", sample = samples,
-                        suffix = allele_suffix),
-        expand("allelic_bams/{sample}.{suffix}.sorted.bam.bai", sample = samples,
-                        suffix = allele_suffix),
-        expand("bamCoverage/allele_specific/{sample}.{suffix}.seq_depth_norm.bw", sample = samples,
-                        suffix = ['genome1', 'genome2'])
+            expand(
+                "allelic_bams/{sample}.{suffix}.sorted.bam",
+                sample=samples,
+                suffix=allele_suffix,
+            ),
+            expand(
+                "allelic_bams/{sample}.{suffix}.sorted.bam.bai",
+                sample=samples,
+                suffix=allele_suffix,
+            ),
+            expand(
+                "bamCoverage/allele_specific/{sample}.{suffix}.seq_depth_norm.bw",
+                sample=samples,
+                suffix=["genome1", "genome2"],
+            ),
         ]
-        return(file_list)
+        return file_list
     else:
-        return([])
+        return []
+
 
 def run_whatshap():
     if "allelic-whatshap" in mode:
-        allele_suffix = ['allele_flagged', 'genome1', 'genome2', 'unassigned']
+        allele_suffix = ["allele_flagged", "genome1", "genome2", "unassigned"]
         file_list = [
-        expand("allelic_bams/{sample}.{suffix}.sorted.bam", sample = samples,
-                        suffix = allele_suffix),
-        expand("allelic_bams/{sample}.{suffix}.sorted.bam.bai", sample = samples,
-                        suffix = allele_suffix),
-        expand("bamCoverage/allele_specific/{sample}.{suffix}.seq_depth_norm.bw", sample = samples,
-                        suffix = ['genome1', 'genome2'])
+            expand(
+                "allelic_bams/{sample}.{suffix}.sorted.bam",
+                sample=samples,
+                suffix=allele_suffix,
+            ),
+            expand(
+                "allelic_bams/{sample}.{suffix}.sorted.bam.bai",
+                sample=samples,
+                suffix=allele_suffix,
+            ),
+            expand(
+                "bamCoverage/allele_specific/{sample}.{suffix}.seq_depth_norm.bw",
+                sample=samples,
+                suffix=["genome1", "genome2"],
+            ),
         ]
-        return(file_list)
+        return file_list
     else:
-        return([])
+        return []
+
 
 ### execute before workflow starts #############################################
 ################################################################################
 onstart:
     if "verbose" in config and config["verbose"]:
-        print("--- Workflow parameters --------------------------------------------------------")
+        print(
+            "--- Workflow parameters --------------------------------------------------------"
+        )
         print("samples:", samples)
         print("paired:", pairedEnd)
         print("read extension:", reads)
@@ -204,9 +299,11 @@ onstart:
         print("maximum insert size (Bowtie2 -X):", insertSizeMax)
         print("-" * 80, "\n")
 
-        print("--- Environment ----------------------------------------------------------------")
-        print("$TMPDIR: ",os.getenv('TMPDIR', ""))
-        print("$HOSTNAME: ",os.getenv('HOSTNAME', ""))
+        print(
+            "--- Environment ----------------------------------------------------------------"
+        )
+        print("$TMPDIR: ", os.getenv("TMPDIR", ""))
+        print("$HOSTNAME: ", os.getenv("HOSTNAME", ""))
         print("-" * 80, "\n")
 
     if toolsVersion:
@@ -217,28 +314,33 @@ onstart:
 ### main rule ##################################################################
 ################################################################################
 
+
 rule all:
     input:
         run_FastQC(fastqc),
         run_Trimming(trim, fastqc),
-        expand(aligner + "/{sample}.markdup.bam", sample = samples),
-        expand("Sambamba/{sample}.markdup.txt", sample = samples),
-        expand("filtered_bam/{sample}.filtered.bam", sample = samples),
-        expand("bamCoverage/{sample}.seq_depth_norm.bw", sample = samples),
-        expand("bamCoverage/{sample}.filtered.seq_depth_norm.bw", sample = samples),
+        expand(aligner + "/{sample}.markdup.bam", sample=samples),
+        expand("Sambamba/{sample}.markdup.txt", sample=samples),
+        expand("filtered_bam/{sample}.filtered.bam", sample=samples),
+        expand("bamCoverage/{sample}.seq_depth_norm.bw", sample=samples),
+        expand("bamCoverage/{sample}.filtered.seq_depth_norm.bw", sample=samples),
         run_computeGCBias(GCBias),
         run_deepTools_qc(),
         run_splitBam_ops(),
         make_nmasked_genome(),
         run_allelesp_mapping(),
         run_whatshap(),
-        "multiQC/multiqc_report.html"
+        "multiQC/multiqc_report.html",
+
 
 ### execute after workflow finished ############################################
 ################################################################################
 onsuccess:
     if "verbose" in config and config["verbose"]:
-        print("\n--- DNA mapping workflow finished successfully! --------------------------------\n")
+        print(
+            "\n--- DNA mapping workflow finished successfully! --------------------------------\n"
+        )
+
 
 onerror:
     print("\n !!! ERROR in DNA mapping workflow! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")

--- a/snakePipes/workflows/HiC/Snakefile
+++ b/snakePipes/workflows/HiC/Snakefile
@@ -9,58 +9,71 @@ maindir = os.path.dirname(os.path.dirname(workflow.basedir))
 globals().update(cf.set_env_yamls())
 
 # load config file
-globals().update(cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"]))
+globals().update(
+    cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"])
+)
 # load organism-specific data, i.e. genome indices, annotation, etc.
 globals().update(cf.load_organism_data(genome, maindir, config["verbose"]))
 # return the pipeline version in the log
 cf.get_version()
 
+
 # do workflow specific stuff now
 include: os.path.join(workflow.basedir, "internals.snakefile")
+
 
 ### include modules of other snakefiles ########################################
 ################################################################################
 
+
 # FASTQ: either downsample FASTQ files or create symlinks to input files
 include: os.path.join(maindir, "shared", "rules", "FASTQ.snakefile")
 
+
 # FastQC
 if fastqc:
+
     include: os.path.join(maindir, "shared", "rules", "FastQC.snakefile")
+
 
 # trimming
 if trim:
+
     include: os.path.join(maindir, "shared", "rules", "trimming.snakefile")
 
-#umi_tools
-include: os.path.join(maindir, "shared", "rules", "umi_tools.snakefile")
 
+# umi_tools
+include: os.path.join(maindir, "shared", "rules", "umi_tools.snakefile")
 # HiCExplorer
 include: os.path.join(maindir, "shared", "rules", "hicexplorer.snakefile")
-
 # multiQC
 include: os.path.join(maindir, "shared", "rules", "multiQC.snakefile")
+
 
 ### conditional/optional rules #################################################
 ################################################################################
 def run_FastQC(fastqc):
     if fastqc:
-        return( expand("FastQC/{sample}{read}_fastqc.html", sample = samples, read = reads) )
+        return expand("FastQC/{sample}{read}_fastqc.html", sample=samples, read=reads)
     else:
-        return([])
+        return []
+
 
 def run_Trimming(trim, fastqc):
     if trim and fastqc:
-        return( expand(fastq_dir+"/{sample}{read}.fastq.gz", sample = samples, read = reads) +
-                expand("FastQC_trimmed/{sample}{read}_fastqc.html", sample = samples, read = reads) )
+        return expand(
+            fastq_dir + "/{sample}{read}.fastq.gz", sample=samples, read=reads
+        ) + expand("FastQC_trimmed/{sample}{read}_fastqc.html", sample=samples, read=reads)
     elif trim:
-        return( expand(fastq_dir+"/{sample}{read}.fastq.gz", sample = samples, read = reads) )
+        return expand(fastq_dir + "/{sample}{read}.fastq.gz", sample=samples, read=reads)
     else:
-        return([])
+        return []
+
 
 # get samples to merge
 sample_dict = get_sampleSheet(sampleSheet)
 GROUPS = sample_dict.keys()
+
 
 def run_build_matrices():
     file_list = []
@@ -71,63 +84,131 @@ def run_build_matrices():
         else:
             suffix = "_" + matrixFile_suffix
 
-        file_list.append([
-            expand("HiC_matrices/mergedSamples_{group}"+suffix+matrix_format, group=GROUPS),
-            expand("HiC_matrices/QCplots/mergedSamples_{group}"+suffix+"_diagnostic_plot.pdf", group=GROUPS),
-            expand("HiC_matrices/QCplots/mergedSamples_{group}"+suffix+"_mad_threshold.out", group=GROUPS)
-            ])
+        file_list.append(
+            [
+                expand(
+                    "HiC_matrices/mergedSamples_{group}" + suffix + matrix_format,
+                    group=GROUPS,
+                ),
+                expand(
+                    "HiC_matrices/QCplots/mergedSamples_{group}"
+                    + suffix
+                    + "_diagnostic_plot.pdf",
+                    group=GROUPS,
+                ),
+                expand(
+                    "HiC_matrices/QCplots/mergedSamples_{group}"
+                    + suffix
+                    + "_mad_threshold.out",
+                    group=GROUPS,
+                ),
+            ]
+        )
         if not noCorrect:
-            file_list.append(expand("HiC_matrices_corrected/mergedSamples_{group}"+suffix+".corrected"+matrix_format, group=GROUPS))
+            file_list.append(
+                expand(
+                    "HiC_matrices_corrected/mergedSamples_{group}"
+                    + suffix
+                    + ".corrected"
+                    + matrix_format,
+                    group=GROUPS,
+                )
+            )
             if not noTAD:
-                file_list.append(expand("TADs/mergedSamples_{group}"+suffix+"_boundaries.bed", group=GROUPS))
+                file_list.append(
+                    expand(
+                        "TADs/mergedSamples_{group}" + suffix + "_boundaries.bed",
+                        group=GROUPS,
+                    )
+                )
 
     # BINS TO MERGE??
     elif nBinsToMerge > 0:
         suffix = "_Mbins" + str(nBinsToMerge) + "_" + matrixFile_suffix
-        file_list.append([
-            expand("HiC_matrices/{sample}"+suffix+matrix_format, sample=samples),
-            expand("HiC_matrices/QCplots/{sample}"+suffix+"_diagnostic_plot.pdf", sample=samples),
-            expand("HiC_matrices/QCplots/{sample}"+suffix+"_mad_threshold.out", sample=samples)
-            ])
+        file_list.append(
+            [
+                expand("HiC_matrices/{sample}" + suffix + matrix_format, sample=samples),
+                expand(
+                    "HiC_matrices/QCplots/{sample}" + suffix + "_diagnostic_plot.pdf",
+                    sample=samples,
+                ),
+                expand(
+                    "HiC_matrices/QCplots/{sample}" + suffix + "_mad_threshold.out",
+                    sample=samples,
+                ),
+            ]
+        )
         if not noCorrect:
-            file_list.append(expand("HiC_matrices_corrected/{sample}"+suffix+".corrected"+matrix_format, sample=samples))
+            file_list.append(
+                expand(
+                    "HiC_matrices_corrected/{sample}"
+                    + suffix
+                    + ".corrected"
+                    + matrix_format,
+                    sample=samples,
+                )
+            )
             if not noTAD:
-                file_list.append(expand("TADs/{sample}"+suffix+"_boundaries.bed", sample=samples))
+                file_list.append(
+                    expand("TADs/{sample}" + suffix + "_boundaries.bed", sample=samples)
+                )
     # NOTHING TO MERGE??
     else:
-        suffix = "_"+matrixFile_suffix
-        file_list.append([
-            expand("HiC_matrices/{sample}"+suffix+matrix_format, sample=samples),
-            expand("HiC_matrices/QCplots/{sample}"+suffix+"_diagnostic_plot.pdf", sample=samples),
-            expand("HiC_matrices/QCplots/{sample}"+suffix+"_mad_threshold.out", sample=samples)
-            ])
+        suffix = "_" + matrixFile_suffix
+        file_list.append(
+            [
+                expand("HiC_matrices/{sample}" + suffix + matrix_format, sample=samples),
+                expand(
+                    "HiC_matrices/QCplots/{sample}" + suffix + "_diagnostic_plot.pdf",
+                    sample=samples,
+                ),
+                expand(
+                    "HiC_matrices/QCplots/{sample}" + suffix + "_mad_threshold.out",
+                    sample=samples,
+                ),
+            ]
+        )
         if not noCorrect:
-            file_list.append(expand("HiC_matrices_corrected/{sample}"+suffix+".corrected"+matrix_format, sample=samples))
+            file_list.append(
+                expand(
+                    "HiC_matrices_corrected/{sample}"
+                    + suffix
+                    + ".corrected"
+                    + matrix_format,
+                    sample=samples,
+                )
+            )
             if not noTAD:
-                file_list.append(expand("TADs/{sample}"+suffix+"_boundaries.bed", sample=samples))
+                file_list.append(
+                    expand("TADs/{sample}" + suffix + "_boundaries.bed", sample=samples)
+                )
 
-    return(file_list)
+    return file_list
 
 
 def run_dist_vs_count():
     if distVsCount:
-       return(["dist_vs_counts.png"])
+        return ["dist_vs_counts.png"]
     else:
-       return([])
+        return []
 
 
 ### execute before workflow starts #############################################
 ################################################################################
 onstart:
     if "verbose" in config and config["verbose"]:
-        print("--- Workflow parameters --------------------------------------------------------")
+        print(
+            "--- Workflow parameters --------------------------------------------------------"
+        )
         print("samples:", samples)
         print("fastq dir:", fastq_dir)
         print("-" * 80, "\n")
 
-        print("--- Environment ----------------------------------------------------------------")
-        print("$TMPDIR: ",os.getenv('TMPDIR', ""))
-        print("$HOSTNAME: ",os.getenv('HOSTNAME', ""))
+        print(
+            "--- Environment ----------------------------------------------------------------"
+        )
+        print("$TMPDIR: ", os.getenv("TMPDIR", ""))
+        print("$HOSTNAME: ", os.getenv("HOSTNAME", ""))
         print("-" * 80, "\n")
         print(sample_dict)
 
@@ -137,25 +218,31 @@ onstart:
     if sampleSheet:
         cf.copySampleSheet(sampleSheet, outdir)
 
+
 ### main rule ##################################################################
 ################################################################################
 
+
 rule all:
     input:
-        expand("FASTQ/{sample}{read}.fastq.gz", sample = samples, read = reads),
+        expand("FASTQ/{sample}{read}.fastq.gz", sample=samples, read=reads),
         run_FastQC(fastqc),
         run_Trimming(trim, fastqc),
-        expand(aligner + "/{sample}{read}.bam", sample = samples, read = reads),
+        expand(aligner + "/{sample}{read}.bam", sample=samples, read=reads),
         run_build_matrices(),
-        expand("HiC_matrices/QCplots/{sample}_QC/QC.log", sample = samples),
+        expand("HiC_matrices/QCplots/{sample}_QC/QC.log", sample=samples),
         run_dist_vs_count(),
-        "multiQC/multiqc_report.html"
+        "multiQC/multiqc_report.html",
+
 
 ### execute after workflow finished ############################################
 ################################################################################
 onsuccess:
     if "verbose" in config and config["verbose"]:
-        print("\n--- Hi-C workflow finished successfully! --------------------------------\n")
+        print(
+            "\n--- Hi-C workflow finished successfully! --------------------------------\n"
+        )
+
 
 onerror:
     print("\n !!! ERROR in HI-C workflow! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")

--- a/snakePipes/workflows/WGBS/Snakefile
+++ b/snakePipes/workflows/WGBS/Snakefile
@@ -8,21 +8,25 @@ import snakePipes.common_functions as cf
 
 ### snakemake_workflows initialization ########################################
 maindir = os.path.dirname(os.path.dirname(workflow.basedir))
-workflow_tools=os.path.join(maindir, "shared", "tools")
-workflow_rscripts=os.path.join(maindir, "shared", "rscripts")
+workflow_tools = os.path.join(maindir, "shared", "tools")
+workflow_rscripts = os.path.join(maindir, "shared", "rscripts")
 
 # load conda ENVs (path is relative to "shared/rules" directory)
 globals().update(cf.set_env_yamls())
 
 # load config file
-globals().update(cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"]))
+globals().update(
+    cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"])
+)
 # load organism-specific data, i.e. genome indices, annotation, etc.
 globals().update(cf.load_organism_data(genome, maindir, config["verbose"]))
 # return the pipeline version in the log
 cf.get_version()
 
+
 # do workflow specific stuff now
 include: os.path.join(workflow.basedir, "internals.snakefile")
+
 
 ### include modules of other snakefiles ########################################
 ################################################################################
@@ -34,14 +38,18 @@ if sampleSheet:
 
 # FastQC
 if fastqc:
+
     include: os.path.join(maindir, "shared", "rules", "FastQC.snakefile")
+
 
 # trimming
 if trim:
+
     include: os.path.join(maindir, "shared", "rules", "trimming.snakefile")
 
+
 ### conditional/optional rules #################################################
-#some of those definitions are used to generate output strings for some of the rules
+# some of those definitions are used to generate output strings for some of the rules
 ################################################################################
 
 pipeline = "WGBS"
@@ -53,25 +61,31 @@ else:
 
 # TODO: Still needed?
 idxRange = 2 if pairedEnd else 1
+
+
 def calc_doc(skipDOC):
     if not skipDOC and not skipBamQC:
-        return (["QC_metrics/genomeCoverage.txt",
-                 "QC_metrics/genomeCoverage.png",
-                 "QC_metrics/genomeCoverage.coverageMetrics.txt",
-                 "QC_metrics/CpGCoverage.txt",
-                 "QC_metrics/CpGCoverage.png",
-                 "QC_metrics/CpGCoverage.coverageMetrics.txt"])
+        return [
+            "QC_metrics/genomeCoverage.txt",
+            "QC_metrics/genomeCoverage.png",
+            "QC_metrics/genomeCoverage.coverageMetrics.txt",
+            "QC_metrics/CpGCoverage.txt",
+            "QC_metrics/CpGCoverage.png",
+            "QC_metrics/CpGCoverage.coverageMetrics.txt",
+        ]
     else:
-        return ([])
+        return []
 
 
 def run_FastQC(fastqc):
     if fastqc and not fromBAM:
-        return( expand("FastQC/{sample}{read}_fastqc.html", sample = samples, read = reads[:idxRange]) )
+        return expand(
+            "FastQC/{sample}{read}_fastqc.html", sample=samples, read=reads[:idxRange]
+        )
     elif fastqc and fromBAM:
-        return( expand("FastQC/{sample}_fastqc.html", sample = samples) )
+        return expand("FastQC/{sample}_fastqc.html", sample=samples)
     else:
-        return([])
+        return []
 
 
 def get_outdir(folder_name, target_regions, minCoverage):
@@ -89,7 +103,9 @@ def get_outdir(folder_name, target_regions, minCoverage):
             region_name = region_name[:idx]
     else:
         region_name = "genome"
-    return("{}_{}_{}_minCoverage{}".format(folder_name, sample_name, region_name, minCoverage))
+    return "{}_{}_{}_minCoverage{}".format(
+        folder_name, sample_name, region_name, minCoverage
+    )
 
 
 def run_DMRs(sampleSheet, targetRegions, minCoverage, DMRprograms):
@@ -97,11 +113,17 @@ def run_DMRs(sampleSheet, targetRegions, minCoverage, DMRprograms):
     if not sampleSheet:
         return output
     if "DSS" in DMRprograms:
-        output.append('{}/Stats_report.html'.format(get_outdir("DSS", None, minCoverage)))
+        output.append("{}/Stats_report.html".format(get_outdir("DSS", None, minCoverage)))
     if "metilene" in DMRprograms:
-        output.append('{}/Stats_report.html'.format(get_outdir("metilene", targetRegions, minCoverage)))
+        output.append(
+            "{}/Stats_report.html".format(
+                get_outdir("metilene", targetRegions, minCoverage)
+            )
+        )
     if "dmrseq" in DMRprograms:
-        output.append('{}/Stats_report.html'.format(get_outdir("dmrseq", None, minCoverage)))
+        output.append(
+            "{}/Stats_report.html".format(get_outdir("dmrseq", None, minCoverage))
+        )
     return output
 
 
@@ -109,27 +131,30 @@ def run_deeptools(GCbias):
     if skipBamQC:
         GCbias = False
     if GCbias:
-        return ["QC_metrics/GCbias.freq.txt","QC_metrics/GCbias.png"]
+        return ["QC_metrics/GCbias.freq.txt", "QC_metrics/GCbias.png"]
     else:
-        return ([])
+        return []
+
 
 def run_misc_QC(skipBamQC):
     if not skipBamQC:
-        return ( expand("filtered_bam/{sample}.filtered.bam", sample = samples), 
-                 calc_doc(skipDOC),
-                 'QC_metrics/QC_report.html',
-                 run_deeptools(GCbias),
-                 'multiQC/multiqc_report.html'
-                )
+        return (
+            expand("filtered_bam/{sample}.filtered.bam", sample=samples),
+            calc_doc(skipDOC),
+            "QC_metrics/QC_report.html",
+            run_deeptools(GCbias),
+            "multiQC/multiqc_report.html",
+        )
     else:
-        return ([])
+        return []
 
 
 ### include modules of other snakefiles ########################################
 ##some rules depend on the definitions above
 ################################################################################
 if not fromBAM:
-    #umi_tools
+
+    # umi_tools
     include: os.path.join(maindir, "shared", "rules", "umi_tools.snakefile")
     # FASTQ: either downsample FASTQ files or create symlinks to input files
     include: os.path.join(maindir, "shared", "rules", "FASTQ.snakefile")
@@ -137,31 +162,35 @@ if not fromBAM:
     include: os.path.join(maindir, "shared", "rules", "sambamba.snakefile")
 
 else:
+
     include: os.path.join(maindir, "shared", "rules", "LinkBam.snakefile")
+
 
 # WGBS
 include: os.path.join(maindir, "shared", "rules", "WGBS.snakefile")
-
-
-#bam_filtering
+# bam_filtering
 include: os.path.join(maindir, "shared", "rules", "bam_filtering.snakefile")
-
 # MultiQC
 include: os.path.join(maindir, "shared", "rules", "multiQC.snakefile")
+
 
 ### execute before workflow starts #############################################
 ################################################################################
 onstart:
     if "verbose" in config and config["verbose"]:
-        print("--- Workflow parameters --------------------------------------------------------")
-        print("samples:"+ str(samples))
-        print("input dir:"+ indir)
-        print("-" * 80)#, "\n"
+        print(
+            "--- Workflow parameters --------------------------------------------------------"
+        )
+        print("samples:" + str(samples))
+        print("input dir:" + indir)
+        print("-" * 80)  # , "\n"
 
-        print("--- Environment ----------------------------------------------------------------")
-        print("$TMPDIR: "+os.getenv('TMPDIR', ""))
-        print("$HOSTNAME: "+os.getenv('HOSTNAME', ""))
-        print("-" * 80)#, "\n"
+        print(
+            "--- Environment ----------------------------------------------------------------"
+        )
+        print("$TMPDIR: " + os.getenv("TMPDIR", ""))
+        print("$HOSTNAME: " + os.getenv("HOSTNAME", ""))
+        print("-" * 80)  # , "\n"
 
     if toolsVersion:
         usedEnvs = [CONDA_SHARED_ENV, CONDA_WGBS_ENV]
@@ -169,9 +198,11 @@ onstart:
     if sampleSheet:
         cf.copySampleSheet(sampleSheet, outdir)
 
+
 ### main rule ##################################################################
 ################################################################################
-localrules: download_picard
+localrules:
+    download_picard,
 
 
 rule all:
@@ -182,14 +213,17 @@ rule all:
         expand("MethylDackel/{sample}_CpG.bedGraph", sample=samples),
         expand("MethylDackel/{sample}_CpG.methylation.bw", sample=samples),
         expand("MethylDackel/{sample}_CpG.coverage.bw", sample=samples),
-        run_DMRs(sampleSheet, targetRegions, minCoverage, DMRprograms)        
+        run_DMRs(sampleSheet, targetRegions, minCoverage, DMRprograms),
 
 
 ### execute after workflow finished ############################################
 ################################################################################
 onsuccess:
     if "verbose" in config and config["verbose"]:
-        print("--- WGBS workflow finished successfully! --------------------------------")#\n \n
+        print(
+            "--- WGBS workflow finished successfully! --------------------------------"
+        )  # \n \n
+
 
 onerror:
     print("\n !!! ERROR in WGBS workflow! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")

--- a/snakePipes/workflows/createIndices/Snakefile
+++ b/snakePipes/workflows/createIndices/Snakefile
@@ -4,14 +4,16 @@ import snakePipes.common_functions as cf
 
 ### snakemake_workflows initialization ########################################
 maindir = os.path.dirname(os.path.dirname(workflow.basedir))
-workflow_rscripts=os.path.join(maindir, "shared", "rscripts")
-workflow_tools=os.path.join(maindir, "shared", "tools")
+workflow_rscripts = os.path.join(maindir, "shared", "rscripts")
+workflow_tools = os.path.join(maindir, "shared", "tools")
 
 # load conda ENVs (path is relative to "shared/rules" directory)
 globals().update(cf.set_env_yamls())
 
 # load config file
-globals().update(cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"]))
+globals().update(
+    cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"])
+)
 # return the pipeline version in the log
 cf.get_version()
 
@@ -20,12 +22,22 @@ cf.get_version()
 if config.get("tesmall"):
     import shutil
     from snakemake.io import multiext, unpack, touch
+
     sys.path.insert(0, os.path.join(workflow_tools, "smallrna"))
-    from common import ensure_dir, normalize_genome, download_or_raise, UCSC_BASE, TE_CLASSES
+    from common import (
+        ensure_dir,
+        normalize_genome,
+        download_or_raise,
+        UCSC_BASE,
+        TE_CLASSES,
+    )
     from link_genome import link_genome_fasta
     from fetch_rmsk import fetch_rmsk_txt
     from build_gene_features import (
-        write_raw_exon_bed, write_raw_intron_bed, write_raw_structural_rna, extract_te_from_rmsk,
+        write_raw_exon_bed,
+        write_raw_intron_bed,
+        write_raw_structural_rna,
+        extract_te_from_rmsk,
     )
     from extract_trna_rrna import filter_bed_by_prefix, fix_trna_headers
     from fetch_smallrna_annotation import download_smallrna_raw
@@ -35,115 +47,149 @@ if config.get("tesmall"):
 ################################################################################
 
 # This will eventually be written as a yaml file
-organismDictionary = {'genome_size': 0,
-                      'genome_fasta': '',
-                      'genome_index': '',
-                      'genome_2bit': '',
-                      'genome_dict': '',
-                      'bowtie2_index': '',
-                      'hisat2_index': '',
-                      'bwa_index': '',
-                      'bwa_mem2_index': '',
-                      'bwameth_index': '',
-                      'bwameth2_index': '',
-                      'known_splicesites': '',
-                      'star_index': '',
-                      'salmon_index': '',
-                      'salmon_velocity_index': '',
-                      't2g_velocity': '',
-                      'genes_bed': '',
-                      'genes_gtf': '',
-                      'genes_t2g': '',
-                      'spikein_genes_gtf': '',
-                      'extended_coding_regions_gtf': '',
-                      'blacklist_bed': '',
-                      'spikein_blacklist_bed': '',
-                      'ignoreForNormalization': '',
-                      'rmsk_file': '',
-                      # tesmall_db is TEsmall's --dbfolder value: the TEsmall root,
-                      # NOT including genomes/<build> -- TEsmall looks for a
-                      # genomes/ dir inside --dbfolder itself. tesmall_genome is the
-                      # -g value: the actual build the db was prepared for (see
-                      # --tesmallGenome), read straight back out of this YAML at
-                      # smRNAseq/analysis time instead of re-guessed there.
-                      'tesmall_db': False,
-                      'tesmall_genome': False}
+organismDictionary = {
+    "genome_size": 0,
+    "genome_fasta": "",
+    "genome_index": "",
+    "genome_2bit": "",
+    "genome_dict": "",
+    "bowtie2_index": "",
+    "hisat2_index": "",
+    "bwa_index": "",
+    "bwa_mem2_index": "",
+    "bwameth_index": "",
+    "bwameth2_index": "",
+    "known_splicesites": "",
+    "star_index": "",
+    "salmon_index": "",
+    "salmon_velocity_index": "",
+    "t2g_velocity": "",
+    "genes_bed": "",
+    "genes_gtf": "",
+    "genes_t2g": "",
+    "spikein_genes_gtf": "",
+    "extended_coding_regions_gtf": "",
+    "blacklist_bed": "",
+    "spikein_blacklist_bed": "",
+    "ignoreForNormalization": "",
+    "rmsk_file": "",
+    # tesmall_db is TEsmall's --dbfolder value: the TEsmall root,
+    # NOT including genomes/<build> -- TEsmall looks for a
+    # genomes/ dir inside --dbfolder itself. tesmall_genome is the
+    # -g value: the actual build the db was prepared for (see
+    # --tesmallGenome), read straight back out of this YAML at
+    # smRNAseq/analysis time instead of re-guessed there.
+    "tesmall_db": False,
+    "tesmall_genome": False,
+}
 
-targets = [os.path.join(outdir, x) for x in ["genome_fasta/genome.fa",
-                                             "genome_fasta/genome.fa.fai",
-                                             "genome_fasta/genome.dict",
-                                             "genome_fasta/genome.2bit"]]
+targets = [
+    os.path.join(outdir, x)
+    for x in [
+        "genome_fasta/genome.fa",
+        "genome_fasta/genome.fa.fai",
+        "genome_fasta/genome.dict",
+        "genome_fasta/genome.2bit",
+    ]
+]
 
-organismDictionary['genome_fasta'] = os.path.join(outdir, "genome_fasta/genome.fa")
-organismDictionary['genome_index'] = os.path.join(outdir, "genome_fasta/genome.fa.fai")
-organismDictionary['genome_2bit'] = os.path.join(outdir, "genome_fasta/genome.2bit")
-organismDictionary['genome_dict'] = os.path.join(outdir, "genome_fasta/genome.dict")
+organismDictionary["genome_fasta"] = os.path.join(outdir, "genome_fasta/genome.fa")
+organismDictionary["genome_index"] = os.path.join(outdir, "genome_fasta/genome.fa.fai")
+organismDictionary["genome_2bit"] = os.path.join(outdir, "genome_fasta/genome.2bit")
+organismDictionary["genome_dict"] = os.path.join(outdir, "genome_fasta/genome.dict")
 
 if gtfURL:
-    targets.extend([os.path.join(outdir, x) for x in ["annotation/genes.gtf",
-                                                      "annotation/genes.bed",
-                                                      "annotation/genes.t2g",
-                                                      "annotation/genes.slop.gtf"]])
-    organismDictionary['genes_gtf'] = os.path.join(outdir, "annotation/genes.gtf")
-    organismDictionary['genes_bed'] = os.path.join(outdir, "annotation/genes.bed")
-    organismDictionary['genes_t2g'] = os.path.join(outdir, "annotation/genes.t2g")
-    organismDictionary['extended_coding_regions_gtf'] = os.path.join(outdir, "annotation/genes.slop.gtf")
+    targets.extend(
+        [
+            os.path.join(outdir, x)
+            for x in [
+                "annotation/genes.gtf",
+                "annotation/genes.bed",
+                "annotation/genes.t2g",
+                "annotation/genes.slop.gtf",
+            ]
+        ]
+    )
+    organismDictionary["genes_gtf"] = os.path.join(outdir, "annotation/genes.gtf")
+    organismDictionary["genes_bed"] = os.path.join(outdir, "annotation/genes.bed")
+    organismDictionary["genes_t2g"] = os.path.join(outdir, "annotation/genes.t2g")
+    organismDictionary["extended_coding_regions_gtf"] = os.path.join(
+        outdir, "annotation/genes.slop.gtf"
+    )
 
 if spikeinGtfURL:
     targets.extend([os.path.join(outdir, x) for x in ["annotation/spikein_genes.gtf"]])
-    organismDictionary['spikein_genes_gtf'] = os.path.join(outdir, "annotation/spikein_genes.gtf")
+    organismDictionary["spikein_genes_gtf"] = os.path.join(
+        outdir, "annotation/spikein_genes.gtf"
+    )
 
 if rmskURL:
     targets.extend([os.path.join(outdir, x) for x in ["annotation/rmsk.txt"]])
-    organismDictionary['rmsk_file'] = os.path.join(outdir, "annotation/rmsk.txt")
+    organismDictionary["rmsk_file"] = os.path.join(outdir, "annotation/rmsk.txt")
 
-if 'all' in tools or 'bowtie2' in tools:
+if "all" in tools or "bowtie2" in tools:
     targets.append(os.path.join(outdir, "BowtieIndex/genome.rev.2.bt2"))
-    organismDictionary['bowtie2_index'] = os.path.join(outdir, "BowtieIndex/genome")
+    organismDictionary["bowtie2_index"] = os.path.join(outdir, "BowtieIndex/genome")
 
-if 'all' in tools or 'hisat2' in tools:
+if "all" in tools or "hisat2" in tools:
     targets.append(os.path.join(outdir, "HISAT2Index/genome.6.ht2"))
-    organismDictionary['hisat2_index'] = os.path.join(outdir, "HISAT2Index/genome")
+    organismDictionary["hisat2_index"] = os.path.join(outdir, "HISAT2Index/genome")
     if gtfURL:
         targets.append(os.path.join(outdir, "HISAT2Index/splice_sites.txt"))
-        organismDictionary['known_splicesites'] = os.path.join(outdir, "HISAT2Index/splice_sites.txt")
+        organismDictionary["known_splicesites"] = os.path.join(
+            outdir, "HISAT2Index/splice_sites.txt"
+        )
 
-if 'all' in tools or 'star' in tools:
+if "all" in tools or "star" in tools:
     targets.append(os.path.join(outdir, "STARIndex/SAindex"))
-    organismDictionary['star_index'] = os.path.join(outdir, "STARIndex/")
+    organismDictionary["star_index"] = os.path.join(outdir, "STARIndex/")
 
-if 'all' in tools or 'salmon' in tools:
+if "all" in tools or "salmon" in tools:
     targets.append(os.path.join(outdir, "SalmonIndex/seq.bin"))
-    organismDictionary['salmon_index'] = os.path.join(outdir, "SalmonIndex/")
+    organismDictionary["salmon_index"] = os.path.join(outdir, "SalmonIndex/")
     targets.append(os.path.join(outdir, "SalmonIndex_RNAVelocity/seq.bin"))
-    organismDictionary['salmon_velocity_index'] = os.path.join(outdir, "SalmonIndex_RNAVelocity/")
+    organismDictionary["salmon_velocity_index"] = os.path.join(
+        outdir, "SalmonIndex_RNAVelocity/"
+    )
     targets.append(os.path.join(outdir, "annotation/cDNA_introns.joint.t2g"))
-    organismDictionary['t2g_velocity'] = os.path.join(outdir, "annotation/cDNA_introns.joint.t2g")
+    organismDictionary["t2g_velocity"] = os.path.join(
+        outdir, "annotation/cDNA_introns.joint.t2g"
+    )
 
-if 'all' in tools or 'bwa' in tools:
+if "all" in tools or "bwa" in tools:
     targets.append(os.path.join(outdir, "BWAIndex/genome.fa.sa"))
-    organismDictionary['bwa_index'] = os.path.join(outdir, "BWAIndex/genome.fa")
+    organismDictionary["bwa_index"] = os.path.join(outdir, "BWAIndex/genome.fa")
 
-if 'all' in tools or 'bwa-mem2' in tools:
+if "all" in tools or "bwa-mem2" in tools:
     targets.append(os.path.join(outdir, "BWA-MEM2Index/genome.fa.bwt.2bit.64"))
-    organismDictionary['bwa_mem2_index'] = os.path.join(outdir, "BWA-MEM2Index/genome.fa")
+    organismDictionary["bwa_mem2_index"] = os.path.join(
+        outdir, "BWA-MEM2Index/genome.fa"
+    )
 
-if 'all' in tools or 'bwameth' in tools:
+if "all" in tools or "bwameth" in tools:
     targets.append(os.path.join(outdir, "BWAmethIndex/genome.fa.bwameth.c2t.sa"))
-    organismDictionary['bwameth_index'] = os.path.join(outdir, "BWAmethIndex/genome.fa")
+    organismDictionary["bwameth_index"] = os.path.join(outdir, "BWAmethIndex/genome.fa")
 
-if 'all' in tools or 'bwameth2' in tools:
-    targets.append(os.path.join(outdir, "BWAmeth2Index/genome.fa.bwameth.c2t.bwt.2bit.64"))
-    organismDictionary['bwameth2_index'] = os.path.join(outdir, "BWAmeth2Index/genome.fa")
+if "all" in tools or "bwameth2" in tools:
+    targets.append(
+        os.path.join(outdir, "BWAmeth2Index/genome.fa.bwameth.c2t.bwt.2bit.64")
+    )
+    organismDictionary["bwameth2_index"] = os.path.join(
+        outdir, "BWAmeth2Index/genome.fa"
+    )
 
 if blacklist:
     targets.append(os.path.join(outdir, "annotation/blacklist.bed"))
-    organismDictionary['blacklist_bed'] = os.path.join(outdir, "annotation/blacklist.bed")
+    organismDictionary["blacklist_bed"] = os.path.join(
+        outdir, "annotation/blacklist.bed"
+    )
 
 if spikeinBlacklist:
     targets.append(os.path.join(outdir, "annotation/spikein_blacklist.bed"))
-    organismDictionary['spikein_blacklist_bed'] = os.path.join(outdir, "annotation/spikein_blacklist.bed")
-    
+    organismDictionary["spikein_blacklist_bed"] = os.path.join(
+        outdir, "annotation/spikein_blacklist.bed"
+    )
+
 if tesmall:
     # Not directory(...): individual files inside TEsmall/ (hairpin.bed, TE.bed,
     # etc.) are each their own tracked rule output, and Snakemake disallows a
@@ -151,18 +197,20 @@ if tesmall:
     # (ChildIOException). create_tesmall's own output is a plain sentinel file.
     # Layout: TEsmall/genomes/<tesmallGenome>/{annotation,sequence}/... -- nested
     # under the build name (see createIndices.snakefile).
-    targets.append(os.path.join(outdir, "TEsmall", "genomes", tesmallGenome, ".tesmall_done"))
+    targets.append(
+        os.path.join(outdir, "TEsmall", "genomes", tesmallGenome, ".tesmall_done")
+    )
     # tesmall_db is the TEsmall root (--dbfolder), NOT the genomes/<build>
     # subdir -- TEsmall itself looks for a genomes/ dir inside --dbfolder.
-    organismDictionary['tesmall_db'] = os.path.join(outdir, "TEsmall")
-    organismDictionary['tesmall_genome'] = tesmallGenome
+    organismDictionary["tesmall_db"] = os.path.join(outdir, "TEsmall")
+    organismDictionary["tesmall_genome"] = tesmallGenome
 
 ignore = []
 if ignoreForNormalization:
     f = open(ignoreForNormalization)
     ignore = [line.strip() for line in f]
     f.close()
-    organismDictionary['ignoreForNormalization'] = " ".join(ignore)
+    organismDictionary["ignoreForNormalization"] = " ".join(ignore)
 
 if effectiveGenomeSize and effectiveGenomeSize > 0:
     os.makedirs(os.path.join(outdir, "genome_fasta"), exist_ok=True)
@@ -173,13 +221,18 @@ else:
     targets.append(os.path.join(outdir, "genome_fasta", "effectiveSize"))
 
 globals().update(organismDictionary)
+
+
 include: os.path.join(maindir, "shared", "rules", "createIndices.snakefile")
+
 
 ### execute before workflow starts #############################################
 ################################################################################
 onstart:
     if "verbose" in config and config["verbose"]:
-        print("--- Workflow parameters --------------------------------------------------------")
+        print(
+            "--- Workflow parameters --------------------------------------------------------"
+        )
         print("output directory: ", outdir)
         print("genome name: ", genome)
         print("genome URL/path: ", genomeURL)
@@ -190,37 +243,45 @@ onstart:
         print("ignore for normalization: ", " ".join(ignore))
         print("-" * 80, "\n")
 
-        print("--- Environment ----------------------------------------------------------------")
-        print("$TMPDIR: ",os.getenv('TMPDIR', ""))
-        print("$HOSTNAME: ",os.getenv('HOSTNAME', ""))
+        print(
+            "--- Environment ----------------------------------------------------------------"
+        )
+        print("$TMPDIR: ", os.getenv("TMPDIR", ""))
+        print("$HOSTNAME: ", os.getenv("HOSTNAME", ""))
         print("-" * 80, "\n")
 
     if toolsVersion:
         usedEnvs = [CONDA_SHARED_ENV, CONDA_CREATE_INDEX_ENV]
         cf.writeTools(usedEnvs, outdir, "createIndices", maindir)
 
+
 ### main rule ##################################################################
 ################################################################################
 rule all:
-    input: targets
+    input:
+        targets,
+
 
 ### execute after workflow finished ############################################
 ################################################################################
 onsuccess:
     f = open(os.path.join(outdir, "genome_fasta", "effectiveSize"))
-    organismDictionary['genome_size'] = int(float(f.read().strip()))
+    organismDictionary["genome_size"] = int(float(f.read().strip()))
     f.close()
     orgDir_yamlPath = os.path.join(maindir, organismsDir, f"{genome}.yaml")
     outDir_yamlPath = os.path.join(outdir, f"{genome}.yaml")
     try:
-        cf.write_configfile(orgDir_yamlPath, organismDictionary,trafo=None)
+        cf.write_configfile(orgDir_yamlPath, organismDictionary, trafo=None)
         print(f"{genome} yaml written to {orgDir_yamlPath}")
     except (PermissionError, FileNotFoundError) as e:
         print(f"Error writing in the organism dir {e}")
-    cf.write_configfile(outDir_yamlPath, organismDictionary,trafo=None)
+    cf.write_configfile(outDir_yamlPath, organismDictionary, trafo=None)
     print(f"{genome} yaml written to {outDir_yamlPath}")
     if "verbose" in config and config["verbose"]:
-        print("\n--- index creation workflow finished successfully! --------------------------------\n")
+        print(
+            "\n--- index creation workflow finished successfully! --------------------------------\n"
+        )
+
 
 onerror:
     print("\n !!! ERROR in index creation workflow! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")

--- a/snakePipes/workflows/mRNAseq/Snakefile
+++ b/snakePipes/workflows/mRNAseq/Snakefile
@@ -10,131 +10,184 @@ maindir = os.path.dirname(os.path.dirname(workflow.basedir))
 globals().update(cf.set_env_yamls())
 
 # load config file
-globals().update(cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"]))
+globals().update(
+    cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"])
+)
 # load organism-specific data, i.e. genome indices, annotation, etc.
 globals().update(cf.load_organism_data(genome, maindir, config["verbose"]))
 # return the pipeline version in the log
 cf.get_version()
 
+
 # do workflow specific stuff now
 include: os.path.join(workflow.basedir, "internals.snakefile")
+
 
 ### include modules of other snakefiles ########################################
 ################################################################################
 
-# deeptools cmds
-include: os.path.join(maindir, "shared", "tools" , "deeptools_cmds.snakefile")
 
+# deeptools cmds
+include: os.path.join(maindir, "shared", "tools", "deeptools_cmds.snakefile")
 ## filtered annotation (GTF)
 include: os.path.join(maindir, "shared", "rules", "filterGTF.snakefile")
 
+
 if not "allelic-counting" in mode:
+
     ## bamCoverage_RPKM
     include: os.path.join(maindir, "shared", "rules", "deepTools_RNA.snakefile")
 
 
 if not fromBAM:
+
     ## FASTQ: either downsample FASTQ files or create symlinks to input files
     include: os.path.join(maindir, "shared", "rules", "FASTQ.snakefile")
 
     ## FastQC
     if fastqc:
+
         include: os.path.join(maindir, "shared", "rules", "FastQC.snakefile")
 
     ## Trim
     if trim:
+
         include: os.path.join(maindir, "shared", "rules", "trimming.snakefile")
-
     ## sambamba
-    include:os.path.join(maindir, "shared", "rules", "sambamba.snakefile")
-
+    include: os.path.join(maindir, "shared", "rules", "sambamba.snakefile")
     ## bam filtering
     include: os.path.join(maindir, "shared", "rules", "bam_filtering.snakefile")
-    
-    #umi_tools
+    # umi_tools
     include: os.path.join(maindir, "shared", "rules", "umi_tools.snakefile")
 
     ## Allele-specific JOBS
     if "allelic-mapping" in mode:
         genome_alias = os.path.splitext(os.path.basename(genome))[0]
         # Updated global vars if mode = "allelic-mapping"
-        if allele_mode == 'create_and_map':
-            star_index_allelic = 'snp_genome/star_Nmasked/Genome'
+        if allele_mode == "create_and_map":
+            star_index_allelic = "snp_genome/star_Nmasked/Genome"
             if len(strains) == 1:
-                allele_hybrid = 'single'
-                SNPFile = "snp_genome/all_SNPs_" + strains[0] + "_" + genome_alias + ".txt.gz"
+                allele_hybrid = "single"
+                SNPFile = (
+                    "snp_genome/all_SNPs_"
+                    + strains[0]
+                    + "_"
+                    + genome_alias
+                    + ".txt.gz"
+                )
             elif len(strains) == 2:
-                allele_hybrid = 'dual'
-                SNPFile = "snp_genome/all_" + strains[1] + "_SNPs_" + strains[0] + "_reference.based_on_" + genome_alias + ".txt"
+                allele_hybrid = "dual"
+                SNPFile = (
+                    "snp_genome/all_"
+                    + strains[1]
+                    + "_SNPs_"
+                    + strains[0]
+                    + "_reference.based_on_"
+                    + genome_alias
+                    + ".txt"
+                )
 
             include: os.path.join(maindir, "shared", "rules", "masked_genomeIndex.snakefile")
-        elif allele_mode == 'map_only':
+
+        elif allele_mode == "map_only":
             star_index_allelic = NMaskedIndex
             SNPFile = SNPfile
-        ## mapping rules
+
+            ## mapping rules
         include: os.path.join(maindir, "shared", "rules", "RNA_mapping_allelic.snakefile")
         ## SNPsplit
         include: os.path.join(maindir, "shared", "rules", "SNPsplit.snakefile")
         # deepTools QC
         include: os.path.join(maindir, "shared", "rules", "deepTools_RNA_allelic.snakefile")
+
         if "alignment-free" in mode:
+
             include: os.path.join(maindir, "shared", "rules", "Salmon_allelic.snakefile")
             include: os.path.join(maindir, "shared", "rules", "sleuth.singleComp.snakefile")
-#            include: os.path.join(maindir, "shared", "rules", "DESeq2.singleComp.snakefile")
+
+    #            include: os.path.join(maindir, "shared", "rules", "DESeq2.singleComp.snakefile")
     elif "allelic-whatshap" in mode:
+
         include: os.path.join(maindir, "shared", "rules", "RNA_mapping.snakefile")
         include: os.path.join(maindir, "shared", "rules", "whatshap.snakefile")
         include: os.path.join(maindir, "shared", "rules", "deepTools_RNA_allelic.snakefile")
+
         if "alignment-free" in mode:
+
             include: os.path.join(maindir, "shared", "rules", "Salmon_allelic.snakefile")
-            include: os.path.join(maindir, "shared", "rules", "sleuth.singleComp.snakefile")            
+            include: os.path.join(maindir, "shared", "rules", "sleuth.singleComp.snakefile")
+
     else:
+
         # HISAT2/STAR
         include: os.path.join(maindir, "shared", "rules", "RNA_mapping.snakefile")
+
         ## Salmon
         if "alignment-free" in mode:
+
             include: os.path.join(maindir, "shared", "rules", "Salmon.snakefile")
+
             ## Sleuth (on Salmon)
             if sampleSheet:
                 if isMultipleComparison:
+
                     include: os.path.join(maindir, "shared", "rules", "sleuth.multiComp.snakefile")
+
                 else:
+
                     include: os.path.join(maindir, "shared", "rules", "sleuth.singleComp.snakefile")
 
 else:
-    fastqc=False
-    trim=False
-    downsample=None
+    fastqc = False
+    trim = False
+    downsample = None
     if "allelic-mapping" in mode:
         allele_mode = "from_bam"
         star_index_allelic = NMaskedIndex
         SNPFile = SNPfile
+
         # SNPsplit
         include: os.path.join(maindir, "shared", "rules", "SNPsplit.snakefile")
         # deepTools QC
         include: os.path.join(maindir, "shared", "rules", "deepTools_RNA_allelic.snakefile")
+
     elif "allelic-counting" in mode:
         allele_mode = "from_split_bam"
+
         include: os.path.join(maindir, "shared", "rules", "deepTools_RNA_allelic.snakefile")
+
     elif "allelic-whatshap" in mode:
+
         include: os.path.join(maindir, "shared", "rules", "whatshap.snakefile")
         include: os.path.join(maindir, "shared", "rules", "deepTools_RNA_allelic.snakefile")
+
         if "alignment-free" in mode:
+
             include: os.path.join(maindir, "shared", "rules", "Salmon_allelic.snakefile")
             include: os.path.join(maindir, "shared", "rules", "sleuth.singleComp.snakefile")
     include: os.path.join(maindir, "shared", "rules", "LinkBam.snakefile")
 
 
-if "allelic-mapping" in mode or "allelic-counting" in mode or "allelic-whatshap" in mode:
+if (
+    "allelic-mapping" in mode
+    or "allelic-counting" in mode
+    or "allelic-whatshap" in mode
+):
+
     ## featureCounts_allelic
     include: os.path.join(maindir, "shared", "rules", "featureCounts_allelic.snakefile")
+
 else:
+
     ## non-allelic featureCounts
     include: os.path.join(maindir, "shared", "rules", "featureCounts.snakefile")
 
+
 # Three Prime Sequencing mode
 if "three-prime-seq" in mode:
+
     include: os.path.join(maindir, "shared", "rules", "three_prime_seq.snakefile")
+
 
 ##Genomic_contamination
 include: os.path.join(maindir, "shared", "rules", "GenomicContamination.snakefile")
@@ -142,17 +195,34 @@ include: os.path.join(maindir, "shared", "rules", "GenomicContamination.snakefil
 
 ## DESeq2
 if sampleSheet and not "three-prime-seq" in mode:
-    if isMultipleComparison :
+    if isMultipleComparison:
+
         include: os.path.join(maindir, "shared", "rules", "DESeq2.multipleComp.snakefile")
-        if rMats and not "allelic-mapping" in mode and not "allelic-counting" in mode:
+
+        if (
+            rMats
+            and not "allelic-mapping" in mode
+            and not "allelic-counting" in mode
+        ):
+
             include: os.path.join(maindir, "shared", "rules", "rMats.multipleComp.snakefile")
+
     else:
+
         include: os.path.join(maindir, "shared", "rules", "DESeq2.singleComp.snakefile")
-        if rMats and not "allelic-mapping" in mode and not "allelic-counting" in mode:
+
+        if (
+            rMats
+            and not "allelic-mapping" in mode
+            and not "allelic-counting" in mode
+        ):
+
             include: os.path.join(maindir, "shared", "rules", "rMats.singleComp.snakefile")
+
 
 ## MultiQC
 include: os.path.join(maindir, "shared", "rules", "multiQC.snakefile")
+
 
 ### conditional/optional rules #################################################
 ################################################################################
@@ -161,9 +231,9 @@ def run_FastQC(fastqc):
     if not pairedEnd:
         readsUse = [reads[0]]
     if fastqc:
-        return( expand("FastQC/{sample}{read}_fastqc.html", sample = samples, read = readsUse) )
+        return expand("FastQC/{sample}{read}_fastqc.html", sample=samples, read=readsUse)
     else:
-        return([])
+        return []
 
 
 def run_Trimming(trim, fastqc):
@@ -171,183 +241,338 @@ def run_Trimming(trim, fastqc):
     if not pairedEnd:
         readsUse = [reads[0]]
     if trim and fastqc:
-        return( expand(fastq_dir+"/{sample}{read}.fastq.gz", sample = samples, read = readsUse) +
-                expand("FastQC_trimmed/{sample}{read}_fastqc.html", sample = samples, read = readsUse) )
+        return expand(
+            fastq_dir + "/{sample}{read}.fastq.gz", sample=samples, read=readsUse
+        ) + expand(
+            "FastQC_trimmed/{sample}{read}_fastqc.html", sample=samples, read=readsUse
+        )
     elif trim:
-        return( expand(fastq_dir+"/{sample}{read}.fastq.gz", sample = samples, read = readsUse) )
+        return expand(fastq_dir + "/{sample}{read}.fastq.gz", sample=samples, read=readsUse)
     else:
-        return([])
+        return []
 
 
 def run_alignment_free():
     if "alignment-free" in mode:
         if not "allelic-mapping" in mode and not "allelic-whatshap" in mode:
             file_list = [
-            expand("Salmon/{sample}.quant.sf", sample=samples),
-            "Salmon/TPM.transcripts.tsv",
-            "Salmon/counts.transcripts.tsv",
-            expand("Salmon/{sample}/abundance.h5", sample=samples) ]
+                expand("Salmon/{sample}.quant.sf", sample=samples),
+                "Salmon/TPM.transcripts.tsv",
+                "Salmon/counts.transcripts.tsv",
+                expand("Salmon/{sample}/abundance.h5", sample=samples),
+            ]
 
             if sampleSheet:
                 sample_name = os.path.splitext(os.path.basename(sampleSheet))[0]
                 if not isMultipleComparison:
-                    file_list.append( ["DESeq2_Salmon_{}/DESeq2.session_info.txt".format(sample_name)]) if not LRT else file_list.append( ["DESeq2_Salmon_{}_LRT/DESeq2.session_info.txt".format(sample_name)])
+                    (
+                        file_list.append(
+                            ["DESeq2_Salmon_{}/DESeq2.session_info.txt".format(sample_name)]
+                        )
+                        if not LRT
+                        else file_list.append(
+                            [
+                                "DESeq2_Salmon_{}_LRT/DESeq2.session_info.txt".format(
+                                    sample_name
+                                )
+                            ]
+                        )
+                    )
                     if cf.check_replicates(sampleSheet):
-                        file_list.append( ["sleuth_Salmon_{}/so.rds".format(sample_name)] )
+                        file_list.append(["sleuth_Salmon_{}/so.rds".format(sample_name)])
                     if rMats:
-                        file_list.append( ["rMats_{}/RI.MATS.JCEC.txt".format(sample_name)] )
-                        file_list.append( ["rMats_{}/b2.csv".format(sample_name)] )
+                        file_list.append(["rMats_{}/RI.MATS.JCEC.txt".format(sample_name)])
+                        file_list.append(["rMats_{}/b2.csv".format(sample_name)])
                 else:
-                    file_list.append(expand("DESeq2_Salmon_{}".format(sample_name) + ".{compGroup}/DESeq2.session_info.txt",compGroup=cf.returnComparisonGroups(sampleSheet))) if not LRT else file_list.append(expand("DESeq2_Salmon_{}".format(sample_name) + ".{compGroup}_LRT/DESeq2.session_info.txt",compGroup=cf.returnComparisonGroups(sampleSheet)))
-                    file_list.append(expand("sleuth_Salmon_{}".format(sample_name) + ".{compGroup}/so.rds",compGroup=cf.returnComparisonGroups(sampleSheet)))
+                    (
+                        file_list.append(
+                            expand(
+                                "DESeq2_Salmon_{}".format(sample_name)
+                                + ".{compGroup}/DESeq2.session_info.txt",
+                                compGroup=cf.returnComparisonGroups(sampleSheet),
+                            )
+                        )
+                        if not LRT
+                        else file_list.append(
+                            expand(
+                                "DESeq2_Salmon_{}".format(sample_name)
+                                + ".{compGroup}_LRT/DESeq2.session_info.txt",
+                                compGroup=cf.returnComparisonGroups(sampleSheet),
+                            )
+                        )
+                    )
+                    file_list.append(
+                        expand(
+                            "sleuth_Salmon_{}".format(sample_name) + ".{compGroup}/so.rds",
+                            compGroup=cf.returnComparisonGroups(sampleSheet),
+                        )
+                    )
                     if rMats:
-                        file_list.append(expand("rMats_{}".format(sample_name) + ".{compGroup}/RI.MATS.JCEC.txt",compGroup=cf.returnComparisonGroups(sampleSheet)))
-                        file_list.append(expand("rMats_{}".format(sample_name) + ".{compGroup}/b2.csv",compGroup=cf.returnComparisonGroups(sampleSheet)))
+                        file_list.append(
+                            expand(
+                                "rMats_{}".format(sample_name)
+                                + ".{compGroup}/RI.MATS.JCEC.txt",
+                                compGroup=cf.returnComparisonGroups(sampleSheet),
+                            )
+                        )
+                        file_list.append(
+                            expand(
+                                "rMats_{}".format(sample_name) + ".{compGroup}/b2.csv",
+                                compGroup=cf.returnComparisonGroups(sampleSheet),
+                            )
+                        )
         else:
             file_list = [
-            expand("SalmonAllelic/{sample}.{allelic_suffix}.quant.sf", sample=samples,allelic_suffix=allelic_suffix),
-            "SalmonAllelic/TPM.transcripts.tsv",
-            "SalmonAllelic/counts.transcripts.tsv",
-            expand("SalmonAllelic/{sample}.{allelic_suffix}/abundance.h5", sample=samples,allelic_suffix=allelic_suffix) ]
+                expand(
+                    "SalmonAllelic/{sample}.{allelic_suffix}.quant.sf",
+                    sample=samples,
+                    allelic_suffix=allelic_suffix,
+                ),
+                "SalmonAllelic/TPM.transcripts.tsv",
+                "SalmonAllelic/counts.transcripts.tsv",
+                expand(
+                    "SalmonAllelic/{sample}.{allelic_suffix}/abundance.h5",
+                    sample=samples,
+                    allelic_suffix=allelic_suffix,
+                ),
+            ]
             if sampleSheet:
                 sample_name = os.path.splitext(os.path.basename(sampleSheet))[0]
                 if not isMultipleComparison:
-                    file_list.append( ["DESeq2_SalmonAllelic_{}/DESeq2.session_info.txt".format(sample_name)]) if not LRT else file_list.append( ["DESeq2_SalmonAllelic_{}_LRT/DESeq2.session_info.txt".format(sample_name)])
-                    file_list.append( ["sleuth_SalmonAllelic_{}/so.rds".format(sample_name)] )
-        return(file_list)
+                    (
+                        file_list.append(
+                            [
+                                "DESeq2_SalmonAllelic_{}/DESeq2.session_info.txt".format(
+                                    sample_name
+                                )
+                            ]
+                        )
+                        if not LRT
+                        else file_list.append(
+                            [
+                                "DESeq2_SalmonAllelic_{}_LRT/DESeq2.session_info.txt".format(
+                                    sample_name
+                                )
+                            ]
+                        )
+                    )
+                    file_list.append(["sleuth_SalmonAllelic_{}/so.rds".format(sample_name)])
+        return file_list
     else:
-        return([])
+        return []
 
 
 def run_alignment():
     if "alignment" in mode:
         file_list = [
-        expand("filtered_bam/{sample}.filtered.bam", sample = samples),
-        expand("filtered_bam/{sample}.filtered.bam.bai", sample = samples),
-        expand("featureCounts/{sample}.counts.txt", sample=samples),
-        "featureCounts/counts.tsv"
+            expand("filtered_bam/{sample}.filtered.bam", sample=samples),
+            expand("filtered_bam/{sample}.filtered.bam.bai", sample=samples),
+            expand("featureCounts/{sample}.counts.txt", sample=samples),
+            "featureCounts/counts.tsv",
         ]
         if sampleSheet:
-            #warnings.warn("LRT value is set to " + str(LRT))
+            # warnings.warn("LRT value is set to " + str(LRT))
             sample_name = os.path.splitext(os.path.basename(sampleSheet))[0]
             if not isMultipleComparison:
                 if LRT:
-                    #warnings.warn("LRT value is set to " + str(LRT) + "\n Appending " + "DESeq2_{}_LRT/DESeq2.session_info.txt to file list".format(sample_name))
-                    file_list.append( ["DESeq2_{}_LRT/DESeq2.session_info.txt".format(sample_name)] )
+                    # warnings.warn("LRT value is set to " + str(LRT) + "\n Appending " + "DESeq2_{}_LRT/DESeq2.session_info.txt to file list".format(sample_name))
+                    file_list.append(
+                        ["DESeq2_{}_LRT/DESeq2.session_info.txt".format(sample_name)]
+                    )
                 else:
-                    #warnings.warn("LRT value is set to " + str(LRT) + "\n Appending " + "DESeq2_{}/DESeq2.session_info.txt to file list".format(sample_name))
-                    file_list.append( ["DESeq2_{}/DESeq2.session_info.txt".format(sample_name)] )
+                    # warnings.warn("LRT value is set to " + str(LRT) + "\n Appending " + "DESeq2_{}/DESeq2.session_info.txt to file list".format(sample_name))
+                    file_list.append(
+                        ["DESeq2_{}/DESeq2.session_info.txt".format(sample_name)]
+                    )
                 if rMats:
-                    file_list.append( ["rMats_{}/RI.MATS.JCEC.txt".format(sample_name)] )
-                    file_list.append( ["rMats_{}/b2.csv".format(sample_name)] )
+                    file_list.append(["rMats_{}/RI.MATS.JCEC.txt".format(sample_name)])
+                    file_list.append(["rMats_{}/b2.csv".format(sample_name)])
             else:
                 if LRT:
-                    file_list.append(expand("DESeq2_{}".format(sample_name) + ".{compGroup}_LRT/DESeq2.session_info.txt",compGroup=cf.returnComparisonGroups(sampleSheet)))
+                    file_list.append(
+                        expand(
+                            "DESeq2_{}".format(sample_name)
+                            + ".{compGroup}_LRT/DESeq2.session_info.txt",
+                            compGroup=cf.returnComparisonGroups(sampleSheet),
+                        )
+                    )
                 else:
-                    file_list.append(expand("DESeq2_{}".format(sample_name) + ".{compGroup}/DESeq2.session_info.txt",compGroup=cf.returnComparisonGroups(sampleSheet)))
-                if  rMats:
-                    file_list.append(expand("rMats_{}".format(sample_name) + ".{compGroup}/RI.MATS.JCEC.txt",compGroup=cf.returnComparisonGroups(sampleSheet)))
-                    file_list.append(expand("rMats_{}".format(sample_name) + ".{compGroup}/b2.csv",compGroup=cf.returnComparisonGroups(sampleSheet)))
-        return(file_list)
+                    file_list.append(
+                        expand(
+                            "DESeq2_{}".format(sample_name)
+                            + ".{compGroup}/DESeq2.session_info.txt",
+                            compGroup=cf.returnComparisonGroups(sampleSheet),
+                        )
+                    )
+                if rMats:
+                    file_list.append(
+                        expand(
+                            "rMats_{}".format(sample_name)
+                            + ".{compGroup}/RI.MATS.JCEC.txt",
+                            compGroup=cf.returnComparisonGroups(sampleSheet),
+                        )
+                    )
+                    file_list.append(
+                        expand(
+                            "rMats_{}".format(sample_name) + ".{compGroup}/b2.csv",
+                            compGroup=cf.returnComparisonGroups(sampleSheet),
+                        )
+                    )
+        return file_list
     else:
-        return([])
+        return []
+
 
 def make_nmasked_genome():
-    if allele_mode == 'create_and_map':
-        genome1 = "snp_genome/" + strains[0] + '_SNP_filtering_report.txt'
+    if allele_mode == "create_and_map":
+        genome1 = "snp_genome/" + strains[0] + "_SNP_filtering_report.txt"
         file_list = [
-                genome1,
-                SNPFile,
-                star_index_allelic,
-                ]
-        return(file_list)
+            genome1,
+            SNPFile,
+            star_index_allelic,
+        ]
+        return file_list
     else:
-        return([])
+        return []
+
 
 def run_allelesp_mapping():
-    if "allelic-mapping" in mode or "allelic-counting" in mode or "allelic-whatshap" in mode:
-        allele_suffix = ['allele_flagged', 'genome1', 'genome2', 'unassigned']
+    if (
+        "allelic-mapping" in mode
+        or "allelic-counting" in mode
+        or "allelic-whatshap" in mode
+    ):
+        allele_suffix = ["allele_flagged", "genome1", "genome2", "unassigned"]
         file_list = [
-        expand("allelic_bams/{sample}.{suffix}.sorted.bam", sample = samples,
-                        suffix = allele_suffix),
-        expand("allelic_bams/{sample}.{suffix}.sorted.bam.bai", sample = samples,
-                        suffix = allele_suffix),
-        expand("bamCoverage/allele_specific/{sample}.{suffix}.RPKM.bw", sample = samples,
-                        suffix = ['genome1', 'genome2']),
-        expand("featureCounts/{sample}.allelic_counts.txt", sample=samples),
-        "featureCounts/counts_allelic.tsv"
+            expand(
+                "allelic_bams/{sample}.{suffix}.sorted.bam",
+                sample=samples,
+                suffix=allele_suffix,
+            ),
+            expand(
+                "allelic_bams/{sample}.{suffix}.sorted.bam.bai",
+                sample=samples,
+                suffix=allele_suffix,
+            ),
+            expand(
+                "bamCoverage/allele_specific/{sample}.{suffix}.RPKM.bw",
+                sample=samples,
+                suffix=["genome1", "genome2"],
+            ),
+            expand("featureCounts/{sample}.allelic_counts.txt", sample=samples),
+            "featureCounts/counts_allelic.tsv",
         ]
         if sampleSheet:
             sample_name = os.path.splitext(os.path.basename(sampleSheet))[0]
             if not isMultipleComparison:
-                file_list.append( ["DESeq2_{}/DESeq2.session_info.txt".format(sample_name)] ) if not LRT else file_list.append( ["DESeq2_{}_LRT/DESeq2.session_info.txt".format(sample_name)] )
-                #if rMats:
-                    #file_list.append( ["rMats_{}/RI.MATS.JCEC.txt".format(sample_name)] )
-                    #file_list.append( ["rMats_{}/b2.csv".format(sample_name)] )
+                (
+                    file_list.append(
+                        ["DESeq2_{}/DESeq2.session_info.txt".format(sample_name)]
+                    )
+                    if not LRT
+                    else file_list.append(
+                        ["DESeq2_{}_LRT/DESeq2.session_info.txt".format(sample_name)]
+                    )
+                )
+                # if rMats:
+                # file_list.append( ["rMats_{}/RI.MATS.JCEC.txt".format(sample_name)] )
+                # file_list.append( ["rMats_{}/b2.csv".format(sample_name)] )
             else:
-                file_list.append(expand("DESeq2_{}".format(sample_name) + ".{compGroup}/DESeq2.session_info.txt",compGroup=cf.returnComparisonGroups(sampleSheet))) if not LRT else file_list.append(expand("DESeq2_{}".format(sample_name) + ".{compGroup}_LRT/DESeq2.session_info.txt",compGroup=cf.returnComparisonGroups(sampleSheet)))
-        return(file_list)
+                (
+                    file_list.append(
+                        expand(
+                            "DESeq2_{}".format(sample_name)
+                            + ".{compGroup}/DESeq2.session_info.txt",
+                            compGroup=cf.returnComparisonGroups(sampleSheet),
+                        )
+                    )
+                    if not LRT
+                    else file_list.append(
+                        expand(
+                            "DESeq2_{}".format(sample_name)
+                            + ".{compGroup}_LRT/DESeq2.session_info.txt",
+                            compGroup=cf.returnComparisonGroups(sampleSheet),
+                        )
+                    )
+                )
+        return file_list
     else:
-        return([])
+        return []
+
 
 def run_deepTools_qc():
     if "deepTools_qc" in mode:
         file_list = [
-        expand("bamCoverage/{sample}.RPKM.bw", sample = samples),
-        expand("bamCoverage/{sample}.scaleFactors.bw",sample = samples),
-        expand("bamCoverage/{sample}.coverage.bw", sample = samples),
-        expand("bamCoverage/{sample}.uniqueMappings.fwd.bw", sample = samples),
-        expand("bamCoverage/{sample}.uniqueMappings.rev.bw", sample = samples),
-        "deepTools_qc/plotEnrichment/plotEnrichment.tsv",
-        expand("deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",sample = samples)]
+            expand("bamCoverage/{sample}.RPKM.bw", sample=samples),
+            expand("bamCoverage/{sample}.scaleFactors.bw", sample=samples),
+            expand("bamCoverage/{sample}.coverage.bw", sample=samples),
+            expand("bamCoverage/{sample}.uniqueMappings.fwd.bw", sample=samples),
+            expand("bamCoverage/{sample}.uniqueMappings.rev.bw", sample=samples),
+            "deepTools_qc/plotEnrichment/plotEnrichment.tsv",
+            expand(
+                "deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",
+                sample=samples,
+            ),
+        ]
         if pairedEnd:
             file_list.append("deepTools_qc/bamPEFragmentSize/fragmentSize.metric.tsv")
-        if len(samples)>1:
-            file_list.append( ["deepTools_qc/multiBigwigSummary/coverage.bed.npz",
-                              "deepTools_qc/plotCorrelation/correlation.pearson.bed_coverage.tsv",
-                              "deepTools_qc/plotCorrelation/correlation.spearman.bed_coverage.tsv",
-                              "deepTools_qc/plotPCA/PCA.bed_coverage.tsv"] )
-        if 'allelic-mapping' in mode or 'allelic-whatshap' in mode:
+        if len(samples) > 1:
+            file_list.append(
+                [
+                    "deepTools_qc/multiBigwigSummary/coverage.bed.npz",
+                    "deepTools_qc/plotCorrelation/correlation.pearson.bed_coverage.tsv",
+                    "deepTools_qc/plotCorrelation/correlation.spearman.bed_coverage.tsv",
+                    "deepTools_qc/plotPCA/PCA.bed_coverage.tsv",
+                ]
+            )
+        if "allelic-mapping" in mode or "allelic-whatshap" in mode:
             file_list.append(["deepTools_qc/plotEnrichment/plotEnrichment_allelic.tsv"])
-            if len(samples)>1:
-                file_list.append( ["deepTools_qc/multiBigwigSummary/coverage_allelic.bed.npz",
-                                   "deepTools_qc/plotCorrelation/correlation.pearson.bed_coverage_allelic.tsv",
-                                   "deepTools_qc/plotCorrelation/correlation.spearman.bed_coverage_allelic.tsv",
-                                   "deepTools_qc/plotPCA/PCA.bed_coverage_allelic.tsv"] )
-        return(file_list)
+            if len(samples) > 1:
+                file_list.append(
+                    [
+                        "deepTools_qc/multiBigwigSummary/coverage_allelic.bed.npz",
+                        "deepTools_qc/plotCorrelation/correlation.pearson.bed_coverage_allelic.tsv",
+                        "deepTools_qc/plotCorrelation/correlation.spearman.bed_coverage_allelic.tsv",
+                        "deepTools_qc/plotPCA/PCA.bed_coverage_allelic.tsv",
+                    ]
+                )
+        return file_list
     else:
-        return([])
+        return []
 
 
 def run_threePrimeSeq():
     file_list = []
-    if "three-prime-seq" in mode: 
+    if "three-prime-seq" in mode:
         file_list += [
-            expand("filtered_bam/{sample}.filtered.bam",sample=samples),
+            expand("filtered_bam/{sample}.filtered.bam", sample=samples),
             "three_prime_seq/combined_polyA.png",
             "three_prime_seq/counts.tsv",
-            "featureCounts/counts.tsv"
+            "featureCounts/counts.tsv",
         ]
         if sampleSheet:
             sample_name = os.path.splitext(os.path.basename(sampleSheet))[0]
             if not isMultipleComparison:
-                file_list.append( ["DESeq2_{}/DESeq2.session_info.txt".format(sample_name)] )
+                file_list.append(["DESeq2_{}/DESeq2.session_info.txt".format(sample_name)])
     return file_list
 
 
 def run_GenomicContamination():
     if dnaContam:
-       file_list = ["GenomicContamination/genomic_contamination_featurecount_report.tsv"]
-       return (file_list)
+        file_list = ["GenomicContamination/genomic_contamination_featurecount_report.tsv"]
+        return file_list
     else:
-       return([])
+        return []
+
 
 ### execute before  starts #####################################################
 ################################################################################
 onstart:
     if "verbose" in config and config["verbose"] and not fromBAM:
         print()
-        print("--- Workflow parameters --------------------------------------------------------")
+        print(
+            "--- Workflow parameters --------------------------------------------------------"
+        )
         print("mode:", mode)
         print("samples:", samples)
         print("paired:", pairedEnd)
@@ -358,22 +583,30 @@ onstart:
         print("Sample sheet:", sampleSheet)
         print("-" * 80, "\n")
 
-        print("--- Environment ----------------------------------------------------------------")
-        print("$TMPDIR: ", os.getenv('TMPDIR', ""))
-        print("$HOSTNAME: ", os.getenv('HOSTNAME', ""))
+        print(
+            "--- Environment ----------------------------------------------------------------"
+        )
+        print("$TMPDIR: ", os.getenv("TMPDIR", ""))
+        print("$HOSTNAME: ", os.getenv("HOSTNAME", ""))
         print("-" * 80, "\n")
 
     elif "verbose" in config and config["verbose"] and fromBAM:
-        print("--- Workflow parameters --------------------------------------------------------")
+        print(
+            "--- Workflow parameters --------------------------------------------------------"
+        )
         print("samples:" + str(samples))
         print("input dir:" + indir)
         print("paired:", pairedEnd)
         print("-" * 80)  # , "\n"
 
-        print("--- Environment ----------------------------------------------------------------")
-        print("$TMPDIR: " + os.getenv('TMPDIR', ""))
-        print("$HOSTNAME: " + os.getenv('HOSTNAME', ""))
-        print("-" * 80,)
+        print(
+            "--- Environment ----------------------------------------------------------------"
+        )
+        print("$TMPDIR: " + os.getenv("TMPDIR", ""))
+        print("$HOSTNAME: " + os.getenv("HOSTNAME", ""))
+        print(
+            "-" * 80,
+        )
 
     if toolsVersion:
         usedEnvs = [CONDA_SHARED_ENV, CONDA_RNASEQ_ENV]
@@ -381,22 +614,24 @@ onstart:
     if sampleSheet:
         cf.copySampleSheet(sampleSheet, outdir)
 
+
 ### main rule ##################################################################
 ################################################################################
 
 if not fromBAM:
+
     rule all:
         input:
             run_FastQC(fastqc),
             run_Trimming(trim, fastqc),
-            run_alignment_free(),            # Salmon
-            run_alignment(),                 # classical mapping + counting
-            run_allelesp_mapping(),        # allelic-mapping
+            run_alignment_free(),  # Salmon
+            run_alignment(),  # classical mapping + counting
+            run_allelesp_mapping(),  # allelic-mapping
             make_nmasked_genome(),
             run_deepTools_qc(),
             run_GenomicContamination(),
             run_threePrimeSeq(),
-            "multiQC/multiqc_report.html"
+            "multiQC/multiqc_report.html",
 
 else:
 
@@ -406,13 +641,18 @@ else:
             run_allelesp_mapping(),
             run_deepTools_qc(),
             run_GenomicContamination(),
-            "multiQC/multiqc_report.html"
+            "multiQC/multiqc_report.html",
+
 
 ### execute after  finished ####################################################
 ################################################################################
 onsuccess:
     if "verbose" in config and config["verbose"]:
-        print("\n--- RNA-seq workflow finished successfully! ------------------------------------\n")
+        print(
+            "\n--- RNA-seq workflow finished successfully! ------------------------------------\n"
+        )
+
+
 
 onerror:
     print("\n !!! ERROR in RNA-seq workflow! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")

--- a/snakePipes/workflows/makePairs/Snakefile
+++ b/snakePipes/workflows/makePairs/Snakefile
@@ -30,11 +30,13 @@ include: os.path.join(maindir, "shared", "rules", "FASTQ.snakefile")
 
 # FastQC
 if fastqc:
+
     include: os.path.join(maindir, "shared", "rules", "FastQC.snakefile")
 
 
 # trimming
 if trim:
+
     include: os.path.join(maindir, "shared", "rules", "trimming.snakefile")
 
 
@@ -42,29 +44,32 @@ if trim:
 include: os.path.join(maindir, "shared", "rules", "umi_tools.snakefile")
 
 
-
 # Decision to run allelic mode or not is made on the VCFfile arguments + strains argument
 ALLELICMODE = False
-if config['VCFfile']:
+if config["VCFfile"]:
     # VCFfile set, assert strains are there:
-    if config['strains']:
+    if config["strains"]:
         ALLELICMODE = True
         # If no alignerOpts are set, set default for Xb parsing:
-        if not config['alignerOptions']:
-            config['alignerOptions'] = '-SPu -T0'
+        if not config["alignerOptions"]:
+            config["alignerOptions"] = "-SPu -T0"
+
         # Generation of diploid genome (bwa)
         include: os.path.join(maindir, "shared", "rules", "diploid_genome.snakefile")
         # pairtools: bwa mapping (without sorting),  pairtools rules & multiqc
         include: os.path.join(maindir, "shared", "rules", "pairtools_allelic.snakefile")
-    else:
-        if not config['alignerOptions']:
-            config['alignerOptions'] = '-SP -T0'
-        include: os.path.join(maindir, "shared", "rules", "pairtools.snakefile")
-else:
-    if not config['alignerOptions']:
-        config['alignerOptions'] = '-SP -T0'
-    include: os.path.join(maindir, "shared", "rules", "pairtools.snakefile")
 
+    else:
+        if not config["alignerOptions"]:
+            config["alignerOptions"] = "-SP -T0"
+
+        include: os.path.join(maindir, "shared", "rules", "pairtools.snakefile")
+
+else:
+    if not config["alignerOptions"]:
+        config["alignerOptions"] = "-SP -T0"
+
+    include: os.path.join(maindir, "shared", "rules", "pairtools.snakefile")
 
 
 def run_FastQC(fastqc):
@@ -127,7 +132,7 @@ rule all:
         expand("originalFASTQ/{sample}{read}.fastq.gz", sample=samples, read=reads),
         run_FastQC(fastqc),
         run_Trimming(trim, fastqc),
-        "multiQC/multiqc_report.html"
+        "multiQC/multiqc_report.html",
 
 
 ### execute after workflow finished ############################################

--- a/snakePipes/workflows/ncRNAseq/Snakefile
+++ b/snakePipes/workflows/ncRNAseq/Snakefile
@@ -9,49 +9,58 @@ maindir = os.path.dirname(os.path.dirname(workflow.basedir))
 globals().update(cf.set_env_yamls())
 
 # load config file
-globals().update(cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"]))
+globals().update(
+    cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"])
+)
 # load organism-specific data, i.e. genome indices, annotation, etc.
 globals().update(cf.load_organism_data(genome, maindir, config["verbose"]))
 # return the pipeline version in the log
 cf.get_version()
 
+
 # do workflow specific stuff now
 include: os.path.join(workflow.basedir, "internals.snakefile")
+
 
 ### include modules of other snakefiles ########################################
 ################################################################################
 
-# deeptools cmds
-include: os.path.join(maindir, "shared", "tools" , "deeptools_cmds.snakefile")
 
+# deeptools cmds
+include: os.path.join(maindir, "shared", "tools", "deeptools_cmds.snakefile")
 ## bamCoverage_RPKM
 include: os.path.join(maindir, "shared", "rules", "deepTools_RNA.snakefile")
 
 
 if not fromBAM:
+
     ## FASTQ: either downsample FASTQ files or create symlinks to input files
     include: os.path.join(maindir, "shared", "rules", "FASTQ.snakefile")
     include: os.path.join(maindir, "shared", "rules", "umi_tools.snakefile")
 
     ## FastQC
     if fastqc:
+
         include: os.path.join(maindir, "shared", "rules", "FastQC.snakefile")
 
     ## Trim
     if trim:
+
         include: os.path.join(maindir, "shared", "rules", "trimming.snakefile")
 
 else:
-    fastqc=False
-    trim=False
-    downsample=None
+    fastqc = False
+    trim = False
+    downsample = None
+
     include: os.path.join(maindir, "shared", "rules", "LinkBam.snakefile")
+
 
 ## Align and run TEcounts
 include: os.path.join(maindir, "shared", "rules", "tecounts.snakefile")
-
 ## MultiQC
 include: os.path.join(maindir, "shared", "rules", "multiQC.snakefile")
+
 
 ### conditional/optional rules #################################################
 ################################################################################
@@ -60,9 +69,9 @@ def run_FastQC(fastqc):
     if not pairedEnd:
         readsUse = [reads[0]]
     if fastqc:
-        return( expand("FastQC/{sample}{read}_fastqc.html", sample = samples, read = readsUse) )
+        return expand("FastQC/{sample}{read}_fastqc.html", sample=samples, read=readsUse)
     else:
-        return([])
+        return []
 
 
 def run_Trimming(trim, fastqc):
@@ -70,45 +79,59 @@ def run_Trimming(trim, fastqc):
     if not pairedEnd:
         readsUse = [reads[0]]
     if trim and fastqc:
-        return( expand(fastq_dir+"/{sample}{read}.fastq.gz", sample = samples, read = readsUse) +
-                expand("FastQC_trimmed/{sample}{read}_fastqc.html", sample = samples, read = readsUse) )
+        return expand(
+            fastq_dir + "/{sample}{read}.fastq.gz", sample=samples, read=readsUse
+        ) + expand(
+            "FastQC_trimmed/{sample}{read}_fastqc.html", sample=samples, read=readsUse
+        )
     elif trim:
-        return( expand(fastq_dir+"/{sample}{read}.fastq.gz", sample = samples, read = readsUse) )
+        return expand(fastq_dir + "/{sample}{read}.fastq.gz", sample=samples, read=readsUse)
     else:
-        return([])
+        return []
 
 
 def run_deepTools_qc():
     if "deepTools_qc" in mode:
         file_list = [
-        expand("bamCoverage/{sample}.RPKM.bw", sample = samples),
-        expand("bamCoverage/{sample}.scaleFactors.bw",sample = samples),
-        expand("bamCoverage/{sample}.coverage.bw", sample = samples),
-        expand("bamCoverage/{sample}.uniqueMappings.fwd.bw", sample = samples),
-        expand("bamCoverage/{sample}.uniqueMappings.rev.bw", sample = samples),
-        "deepTools_qc/plotEnrichment/plotEnrichment.tsv",
-        expand("deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",sample = samples)]
+            expand("bamCoverage/{sample}.RPKM.bw", sample=samples),
+            expand("bamCoverage/{sample}.scaleFactors.bw", sample=samples),
+            expand("bamCoverage/{sample}.coverage.bw", sample=samples),
+            expand("bamCoverage/{sample}.uniqueMappings.fwd.bw", sample=samples),
+            expand("bamCoverage/{sample}.uniqueMappings.rev.bw", sample=samples),
+            "deepTools_qc/plotEnrichment/plotEnrichment.tsv",
+            expand(
+                "deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",
+                sample=samples,
+            ),
+        ]
         if pairedEnd:
             file_list.append("deepTools_qc/bamPEFragmentSize/fragmentSize.metric.tsv")
-        if len(samples)>1:
-            file_list.append( ["deepTools_qc/multiBigwigSummary/coverage.bed.npz",
-                              "deepTools_qc/plotCorrelation/correlation.pearson.bed_coverage.tsv",
-                              "deepTools_qc/plotCorrelation/correlation.spearman.bed_coverage.tsv",
-                              "deepTools_qc/plotPCA/PCA.bed_coverage.tsv"] )
-        return(file_list)
+        if len(samples) > 1:
+            file_list.append(
+                [
+                    "deepTools_qc/multiBigwigSummary/coverage.bed.npz",
+                    "deepTools_qc/plotCorrelation/correlation.pearson.bed_coverage.tsv",
+                    "deepTools_qc/plotCorrelation/correlation.spearman.bed_coverage.tsv",
+                    "deepTools_qc/plotPCA/PCA.bed_coverage.tsv",
+                ]
+            )
+        return file_list
     else:
-        return([])
+        return []
 
 
 def run_deseq2():
     if sampleSheet:
         sample_name = os.path.splitext(os.path.basename(sampleSheet))[0]
         if isMultipleComparison:
-            file_list = expand("DESeq2_{}".format(sample_name) + ".{compGroup}/DESeq2.session_info.txt",compGroup=cf.returnComparisonGroups(sampleSheet))
+            file_list = expand(
+                "DESeq2_{}".format(sample_name) + ".{compGroup}/DESeq2.session_info.txt",
+                compGroup=cf.returnComparisonGroups(sampleSheet),
+            )
         else:
             file_list = ["DESeq2_{}/DESeq2.session_info.txt".format(sample_name)]
-        return(file_list)
-    return([])
+        return file_list
+    return []
 
 
 ### execute before  starts #####################################################
@@ -116,7 +139,9 @@ def run_deseq2():
 onstart:
     if "verbose" in config and config["verbose"] and not fromBAM:
         print()
-        print("--- Workflow parameters --------------------------------------------------------")
+        print(
+            "--- Workflow parameters --------------------------------------------------------"
+        )
         print("mode:", mode)
         print("samples:", samples)
         print("paired:", pairedEnd)
@@ -125,22 +150,30 @@ onstart:
         print("Sample sheet:", sampleSheet)
         print("-" * 80, "\n")
 
-        print("--- Environment ----------------------------------------------------------------")
-        print("$TMPDIR: ", os.getenv('TMPDIR', ""))
-        print("$HOSTNAME: ", os.getenv('HOSTNAME', ""))
+        print(
+            "--- Environment ----------------------------------------------------------------"
+        )
+        print("$TMPDIR: ", os.getenv("TMPDIR", ""))
+        print("$HOSTNAME: ", os.getenv("HOSTNAME", ""))
         print("-" * 80, "\n")
 
     elif "verbose" in config and config["verbose"] and fromBAM:
-        print("--- Workflow parameters --------------------------------------------------------")
+        print(
+            "--- Workflow parameters --------------------------------------------------------"
+        )
         print("samples:" + str(samples))
         print("input dir:" + indir)
         print("paired:", pairedEnd)
         print("-" * 80)  # , "\n"
 
-        print("--- Environment ----------------------------------------------------------------")
-        print("$TMPDIR: " + os.getenv('TMPDIR', ""))
-        print("$HOSTNAME: " + os.getenv('HOSTNAME', ""))
-        print("-" * 80,)
+        print(
+            "--- Environment ----------------------------------------------------------------"
+        )
+        print("$TMPDIR: " + os.getenv("TMPDIR", ""))
+        print("$HOSTNAME: " + os.getenv("HOSTNAME", ""))
+        print(
+            "-" * 80,
+        )
 
     if toolsVersion:
         usedEnvs = [CONDA_SHARED_ENV, CONDA_NONCODING_RNASEQ_ENV]
@@ -148,33 +181,40 @@ onstart:
     if sampleSheet:
         cf.copySampleSheet(sampleSheet, outdir)
 
+
 ### main rule ##################################################################
 ################################################################################
 
 if not fromBAM:
-    
+
     rule all:
         input:
-            expand("TEcount/{sample}.cntTable", sample = samples),
+            expand("TEcount/{sample}.cntTable", sample=samples),
             run_FastQC(fastqc),
             run_Trimming(trim, fastqc),
             run_deepTools_qc(),
             run_deseq2(),
-            "multiQC/multiqc_report.html"
+            "multiQC/multiqc_report.html",
 
 else:
+
     rule all:
         input:
-            expand("TEcount/{sample}.cntTable", sample = samples),
+            expand("TEcount/{sample}.cntTable", sample=samples),
             run_deepTools_qc(),
             run_deseq2(),
-            "multiQC/multiqc_report.html"
+            "multiQC/multiqc_report.html",
+
 
 ### execute after  finished ####################################################
 ################################################################################
 onsuccess:
     if "verbose" in config and config["verbose"]:
-        print("\n--- ncRNAseq workflow finished successfully! ------------------------------------\n")
+        print(
+            "\n--- ncRNAseq workflow finished successfully! ------------------------------------\n"
+        )
+
+
 
 onerror:
     print("\n !!! ERROR in ncRNAseq workflow! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")

--- a/snakePipes/workflows/preprocessing/Snakefile
+++ b/snakePipes/workflows/preprocessing/Snakefile
@@ -9,12 +9,16 @@ maindir = os.path.dirname(os.path.dirname(workflow.basedir))
 globals().update(cf.set_env_yamls())
 
 # load config file
-globals().update(cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"]))
+globals().update(
+    cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"])
+)
 # return the pipeline version in the log
 cf.get_version()
 
+
 # do workflow specific stuff now
 include: os.path.join(workflow.basedir, "internals.snakefile")
+
 
 ### include modules of other snakefiles ########################################
 ################################################################################
@@ -37,25 +41,35 @@ if sampleSheet and sampleSheet != "":
     if not pairedEnd:
         readsUse = [reads[0]]
 
+
 include: os.path.join(maindir, "shared", "rules", "preprocessing.snakefile")
-infiles = expand("deduplicatedFASTQ/{sample}{RExt}{ext}", sample=samples, RExt=readsUse, ext=ext)
+
+
+infiles = expand(
+    "deduplicatedFASTQ/{sample}{RExt}{ext}", sample=samples, RExt=readsUse, ext=ext
+)
 
 indir = "deduplicatedFASTQ"
 deduped = infiles
 
+
 ## FASTQ: either downsample FASTQ files or create symlinks to input files
 include: os.path.join(maindir, "shared", "rules", "FASTQ.snakefile")
-
-#umi_tools
+# umi_tools
 include: os.path.join(maindir, "shared", "rules", "umi_tools.snakefile")
+
 
 ## FastQC
 if fastqc:
     trim = False  # the multiQC input checker needs this
+
     include: os.path.join(maindir, "shared", "rules", "FastQC.snakefile")
     include: os.path.join(maindir, "shared", "rules", "multiQC.snakefile")
-else:
+
+
+if not fastqc:
     fastqc = False
+
 
 ### conditional/optional rules #################################################
 ################################################################################
@@ -64,9 +78,11 @@ def run_FastQC(fastqc):
     if not pairedEnd:
         readsUse = [reads[0]]
     if fastqc:
-        return(["multiQC/multiqc_report.html"] + expand("FastQC/{sample}{read}_fastqc.html", sample = samples, read = readsUse))
+        return ["multiQC/multiqc_report.html"] + expand(
+            "FastQC/{sample}{read}_fastqc.html", sample=samples, read=readsUse
+        )
     else:
-        return([])
+        return []
 
 
 ### execute before  starts #####################################################
@@ -74,7 +90,9 @@ def run_FastQC(fastqc):
 onstart:
     if "verbose" in config and config["verbose"]:
         print()
-        print("--- Workflow parameters --------------------------------------------------------")
+        print(
+            "--- Workflow parameters --------------------------------------------------------"
+        )
         print("samples:", samples)
         print("paired:", pairedEnd)
         print("read extension:", reads)
@@ -82,27 +100,36 @@ onstart:
         print("Sample sheet:", sampleSheet)
         print("-" * 80, "\n")
 
-        print("--- Environment ----------------------------------------------------------------")
-        print("$TMPDIR: ", os.getenv('TMPDIR', ""))
-        print("$HOSTNAME: ", os.getenv('HOSTNAME', ""))
+        print(
+            "--- Environment ----------------------------------------------------------------"
+        )
+        print("$TMPDIR: ", os.getenv("TMPDIR", ""))
+        print("$HOSTNAME: ", os.getenv("HOSTNAME", ""))
         print("-" * 80, "\n")
 
     if toolsVersion:
         usedEnvs = [CONDA_SHARED_ENV, CONDA_PREPROCESSING_ENV]
         cf.writeTools(usedEnvs, outdir, "preprocessing", maindir)
 
+
 ### main rule ##################################################################
 ################################################################################
 
+
 rule all:
     input:
-        deduped, run_FastQC(fastqc)
+        deduped,
+        run_FastQC(fastqc),
+
 
 ### execute after  finished ####################################################
 ################################################################################
 onsuccess:
     if "verbose" in config and config["verbose"]:
-        print("\n--- Preprocessing workflow finished successfully! ------------------------------------\n")
+        print(
+            "\n--- Preprocessing workflow finished successfully! ------------------------------------\n"
+        )
+
 
 onerror:
     print("\n !!! ERROR in preprocessing workflow! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")

--- a/snakePipes/workflows/scRNAseq/Snakefile
+++ b/snakePipes/workflows/scRNAseq/Snakefile
@@ -5,41 +5,57 @@ import sys
 
 ### snakemake_workflows initialization ########################################
 maindir = os.path.dirname(os.path.dirname(workflow.basedir))
-workflow_rscripts=os.path.join(maindir, "shared", "rscripts")
+workflow_rscripts = os.path.join(maindir, "shared", "rscripts")
 
 # load conda ENVs (path is relative to "shared/rules" directory)
 globals().update(cf.set_env_yamls())
 
 # load config file
-globals().update(cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"]))
+globals().update(
+    cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"])
+)
 # load organism-specific data, i.e. genome indices, annotation, etc.
 globals().update(cf.load_organism_data(genome, maindir, config["verbose"]))
 # return the pipeline version in the log
 cf.get_version()
 
+
 # do workflow specific stuff now
 include: os.path.join(workflow.basedir, "internals.snakefile")
-
-
 ### include modules of other snakefiles ########################################
 ################################################################################
 include: os.path.join(maindir, "shared", "rules", "FASTQ.snakefile")
-#STARsolo uses filtered GTF for counting
+# STARsolo uses filtered GTF for counting
 include: os.path.join(maindir, "shared", "rules", "filterGTF.snakefile")
-#umi_tools
-if mode=="STARsolo":
+
+
+# umi_tools
+if mode == "STARsolo":
+
     include: os.path.join(maindir, "shared", "rules", "scRNAseq_STARsolo.snakefile")
     include: os.path.join(maindir, "shared", "rules", "sambamba.snakefile")
-    include: os.path.join(maindir, "shared", "tools" , "deeptools_cmds.snakefile")
+    include: os.path.join(maindir, "shared", "tools", "deeptools_cmds.snakefile")
     include: os.path.join(maindir, "shared", "rules", "deepTools_RNA.snakefile")
-    trim=False
-elif mode=="Alevin":
-#    include: os.path.join(maindir, "shared", "rules", "Salmon.snakefile")
+
+    trim = False
+
+elif mode == "Alevin":
+
+    #    include: os.path.join(maindir, "shared", "rules", "Salmon.snakefile")
     include: os.path.join(maindir, "shared", "rules", "scRNAseq_Alevin.snakefile")
-    trim=False
+
+    trim = False
+
+
 pairedEnd = True
+
+
 include: os.path.join(maindir, "shared", "rules", "FastQC.snakefile")
+
+
 pairedEnd = False
+
+
 include: os.path.join(maindir, "shared", "rules", "multiQC.snakefile")
 
 
@@ -48,38 +64,48 @@ include: os.path.join(maindir, "shared", "rules", "multiQC.snakefile")
 
 
 def run_deeptools_qc():
-    if mode=="STARsolo":
+    if mode == "STARsolo":
         file_list = [
-        expand("bamCoverage/{sample}.RPKM.bw", sample = samples),
-        expand("bamCoverage/{sample}.coverage.bw", sample = samples),
-        "deepTools_qc/plotEnrichment/plotEnrichment.tsv"]
-        if len(samples)>1:
-            file_list.append( ["deepTools_qc/multiBigwigSummary/coverage.bed.npz",
-                           "deepTools_qc/plotCorrelation/correlation.pearson.bed_coverage.tsv",
-                           "deepTools_qc/plotCorrelation/correlation.spearman.bed_coverage.tsv",
-                           "deepTools_qc/plotPCA/PCA.bed_coverage.tsv"] )
-        return(file_list)
+            expand("bamCoverage/{sample}.RPKM.bw", sample=samples),
+            expand("bamCoverage/{sample}.coverage.bw", sample=samples),
+            "deepTools_qc/plotEnrichment/plotEnrichment.tsv",
+        ]
+        if len(samples) > 1:
+            file_list.append(
+                [
+                    "deepTools_qc/multiBigwigSummary/coverage.bed.npz",
+                    "deepTools_qc/plotCorrelation/correlation.pearson.bed_coverage.tsv",
+                    "deepTools_qc/plotCorrelation/correlation.spearman.bed_coverage.tsv",
+                    "deepTools_qc/plotPCA/PCA.bed_coverage.tsv",
+                ]
+            )
+        return file_list
     else:
-        return([])
+        return []
 
 
 def run_velocyto(skipVelocyto):
-    if not skipVelocyto :
+    if not skipVelocyto:
         if mode == "STARsolo":
-            return([])
+            return []
         elif mode == "Alevin":
-            file_list = [expand("AlevinForVelocity/{sample}/alevin/quants_mat.gz",sample=samples),
-            "SingleCellExperiment/AlevinForVelocity/merged_samples.RDS"]
-            return(file_list)
+            file_list = [
+                expand("AlevinForVelocity/{sample}/alevin/quants_mat.gz", sample=samples),
+                "SingleCellExperiment/AlevinForVelocity/merged_samples.RDS",
+            ]
+            return file_list
 
     else:
-        return([])
+        return []
+
 
 ### execute before workflow starts #############################################
 ################################################################################
 onstart:
     if "verbose" in config and config["verbose"]:
-        print("--- Workflow parameter ---------------------------------------------------------")
+        print(
+            "--- Workflow parameter ---------------------------------------------------------"
+        )
         print("Input directory:", indir)
         print("Input files:", infiles)
         print("Samples:", samples)
@@ -93,49 +119,68 @@ onstart:
 
         print("-" * 80, "\n")
 
-        print("--- Environment ----------------------------------------------------------------")
-        print("$TMPDIR: ",os.getenv('TMPDIR', ""))
-        print("$HOSTNAME: ",os.getenv('HOSTNAME', ""))
+        print(
+            "--- Environment ----------------------------------------------------------------"
+        )
+        print("$TMPDIR: ", os.getenv("TMPDIR", ""))
+        print("$HOSTNAME: ", os.getenv("HOSTNAME", ""))
         print("-" * 80, "\n")
 
     if toolsVersion:
         usedEnvs = [CONDA_SHARED_ENV, CONDA_scRNASEQ_ENV]
         cf.writeTools(usedEnvs, outdir, "scRNAseq", maindir)
 
+
 ### main rule ##################################################################
 ################################################################################
-if mode=="STARsolo":
-    localrules: gzip_STARsolo_for_seurat
+if mode == "STARsolo":
+
+    localrules:
+        gzip_STARsolo_for_seurat,
+
     rule all:
         input:
-            expand("STARsolo/{sample}.sorted.bam",sample = samples),
+            expand("STARsolo/{sample}.sorted.bam", sample=samples),
             "STARsolo/Report.tsv",
             run_deeptools_qc(),
             "deepTools_qc/bamPEFragmentSize/fragmentSize.metric.tsv",
-            expand("deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",sample = samples),
+            expand(
+                "deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",
+                sample=samples,
+            ),
             "multiQC/multiqc_report.html",
             "Seurat/STARsolo_filtered/merged_samples.RDS",
             "Seurat/STARsolo_raw/merged_samples.RDS",
             "Seurat/STARsolo_raw_RmEmptyDrops/merged_samples.RDS",
-            run_velocyto(skipVelocyto)
-elif mode=="Alevin":
-    localrules: filter_gtf, gtf_to_files, cut_t2g
+            run_velocyto(skipVelocyto),
+
+elif mode == "Alevin":
+
+    localrules:
+        filter_gtf,
+        gtf_to_files,
+        cut_t2g,
+
     rule all:
         input:
-            expand("originalFASTQ/{sample}{read}.fastq.gz", sample = samples, read=reads),
-            expand("FastQC/{sample}{read}_fastqc.html", sample = samples, read=reads),
+            expand("originalFASTQ/{sample}{read}.fastq.gz", sample=samples, read=reads),
+            expand("FastQC/{sample}{read}_fastqc.html", sample=samples, read=reads),
             "Annotation/genes.slim.t2g",
-            expand("Alevin/{sample}/alevin/quants_mat.gz",sample = samples),
+            expand("Alevin/{sample}/alevin/quants_mat.gz", sample=samples),
             expand("multiQC/Alevin_{sample}.html", sample=samples),
             "multiQC/multiqc_report.html",
-            run_velocyto(skipVelocyto)
+            run_velocyto(skipVelocyto),
 
 
 ### execute after workflow finished ############################################
 ################################################################################
 onsuccess:
     if "verbose" in config and config["verbose"]:
-        print("\n--- scRNAseq workflow finished successfully! --------------------------------\n")
+        print(
+            "\n--- scRNAseq workflow finished successfully! --------------------------------\n"
+        )
+
+
 
 onerror:
     print("\n !!! ERROR in scRNAseq workflow! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")

--- a/snakePipes/workflows/smRNAseq/Snakefile
+++ b/snakePipes/workflows/smRNAseq/Snakefile
@@ -8,41 +8,47 @@ maindir = os.path.dirname(os.path.dirname(workflow.basedir))
 # load conda ENVs (path is relative to "shared/rules" directory)
 globals().update(cf.set_env_yamls())
 # load config file
-globals().update(cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"]))
+globals().update(
+    cf.load_configfile(workflow.overwrite_configfiles[0], config["verbose"])
+)
 # load organism-specific data, i.e. genome indices, annotation, etc.
 globals().update(cf.load_organism_data(genome, maindir, config["verbose"]))
 # return the pipeline version in the log
 cf.get_version()
 
+
 # do workflow specific stuff now
 include: os.path.join(workflow.basedir, "internals.snakefile")
+
 
 ### include modules of other snakefiles ########################################
 ################################################################################
 
+
 # deeptools cmds
-include: os.path.join(maindir, "shared", "tools" , "deeptools_cmds.snakefile")
-
-
+include: os.path.join(maindir, "shared", "tools", "deeptools_cmds.snakefile")
 include: os.path.join(maindir, "shared", "rules", "deepTools_RNA.snakefile")
-
 # Annotation/genes.filtered.{gtf,bed} -- read by deepTools_RNA.snakefile's
 # plotEnrichment/multiBamSummary_bed/multiBigwigSummary_bed rules.
 include: os.path.join(maindir, "shared", "rules", "filterGTF.snakefile")
 
 
 if not fromBAM:
+
     ## FASTQ: either downsample FASTQ files or create symlinks to input files
     include: os.path.join(maindir, "shared", "rules", "FASTQ.snakefile")
     include: os.path.join(maindir, "shared", "rules", "umi_tools.snakefile")
 
     ## FastQC
     if fastqc:
+
         include: os.path.join(maindir, "shared", "rules", "FastQC.snakefile")
 
     ## Trim
     if trim:
+
         include: os.path.join(maindir, "shared", "rules", "tesmall.snakefile")
+
 
 ## MultiQC
 include: os.path.join(maindir, "shared", "rules", "multiQC.snakefile")
@@ -55,51 +61,67 @@ def run_FastQC(fastqc):
     if not pairedEnd:
         readsUse = [reads[0]]
     if fastqc:
-        return( expand("FastQC/{sample}{read}_fastqc.html", sample = samples, read = readsUse) )
+        return expand("FastQC/{sample}{read}_fastqc.html", sample=samples, read=readsUse)
     else:
-        return([])
+        return []
+
 
 def run_Trimming(trim, fastqc):
     readsUse = reads
     if not pairedEnd:
         readsUse = [reads[0]]
     if trim and fastqc:
-        return( expand(fastq_dir+"/{sample}.fastq.gz", sample = samples) +
-                expand("FastQC_trimmed/{sample}_fastqc.html", sample = samples) )
+        return expand(fastq_dir + "/{sample}.fastq.gz", sample=samples) + expand(
+            "FastQC_trimmed/{sample}_fastqc.html", sample=samples
+        )
     elif trim:
-        return( expand(os.path.join(outdir,"FASTQ_fastp","{sample}.fastq.gz"), sample = samples )+
-                expand(os.path.join(outdir,'TEsmallOut','TEsmall.done')) +
-                expand(os.path.join(outdir,'TEsmallOut','count_summary_plot.pdf')) )
+        return (
+            expand(os.path.join(outdir, "FASTQ_fastp", "{sample}.fastq.gz"), sample=samples)
+            + expand(os.path.join(outdir, "TEsmallOut", "TEsmall.done"))
+            + expand(os.path.join(outdir, "TEsmallOut", "count_summary_plot.pdf"))
+        )
     else:
-        return([])
+        return []
+
 
 def run_deepTools_qc():
     if "deepTools_qc" in mode:
         file_list = [
-        expand("bamCoverage/{sample}.RPKM.bw", sample = samples),
-        expand("bamCoverage/{sample}.scaleFactors.bw",sample = samples),
-        expand("bamCoverage/{sample}.coverage.bw", sample = samples),
-        expand("bamCoverage/{sample}.uniqueMappings.fwd.bw", sample = samples),
-        expand("bamCoverage/{sample}.uniqueMappings.rev.bw", sample = samples),
-        "deepTools_qc/plotEnrichment/plotEnrichment.tsv",
-        expand("deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",sample = samples)]
+            expand("bamCoverage/{sample}.RPKM.bw", sample=samples),
+            expand("bamCoverage/{sample}.scaleFactors.bw", sample=samples),
+            expand("bamCoverage/{sample}.coverage.bw", sample=samples),
+            expand("bamCoverage/{sample}.uniqueMappings.fwd.bw", sample=samples),
+            expand("bamCoverage/{sample}.uniqueMappings.rev.bw", sample=samples),
+            "deepTools_qc/plotEnrichment/plotEnrichment.tsv",
+            expand(
+                "deepTools_qc/estimateReadFiltering/{sample}_filtering_estimation.txt",
+                sample=samples,
+            ),
+        ]
         if pairedEnd:
             file_list.append("deepTools_qc/bamPEFragmentSize/fragmentSize.metric.tsv")
-        if len(samples)>1:
-            file_list.append( ["deepTools_qc/multiBigwigSummary/coverage.bed.npz",
-                              "deepTools_qc/plotCorrelation/correlation.pearson.bed_coverage.tsv",
-                              "deepTools_qc/plotCorrelation/correlation.spearman.bed_coverage.tsv",
-                              "deepTools_qc/plotPCA/PCA.bed_coverage.tsv"] )
-        return(file_list)
+        if len(samples) > 1:
+            file_list.append(
+                [
+                    "deepTools_qc/multiBigwigSummary/coverage.bed.npz",
+                    "deepTools_qc/plotCorrelation/correlation.pearson.bed_coverage.tsv",
+                    "deepTools_qc/plotCorrelation/correlation.spearman.bed_coverage.tsv",
+                    "deepTools_qc/plotPCA/PCA.bed_coverage.tsv",
+                ]
+            )
+        return file_list
     else:
-        return([])
+        return []
+
 
 ### execute before  starts #####################################################
 ################################################################################
 onstart:
     if "verbose" in config and config["verbose"] and not fromBAM:
         print()
-        print("--- Workflow parameters --------------------------------------------------------")
+        print(
+            "--- Workflow parameters --------------------------------------------------------"
+        )
         print("mode:", mode)
         print("samples:", samples)
         print("paired:", pairedEnd)
@@ -107,25 +129,33 @@ onstart:
         print("fastq dir:", fastq_dir)
         print("filter GTF:", filterGTF)
         print("Sample sheet:", sampleSheet)
-        print("TEsmall: ",tesmall_db)
+        print("TEsmall: ", tesmall_db)
         print("-" * 80, "\n")
 
-        print("--- Environment ----------------------------------------------------------------")
-        print("$TMPDIR: ", os.getenv('TMPDIR', ""))
-        print("$HOSTNAME: ", os.getenv('HOSTNAME', ""))
+        print(
+            "--- Environment ----------------------------------------------------------------"
+        )
+        print("$TMPDIR: ", os.getenv("TMPDIR", ""))
+        print("$HOSTNAME: ", os.getenv("HOSTNAME", ""))
         print("-" * 80, "\n")
 
     elif "verbose" in config and config["verbose"] and fromBAM:
-        print("--- Workflow parameters --------------------------------------------------------")
+        print(
+            "--- Workflow parameters --------------------------------------------------------"
+        )
         print("samples:" + str(samples))
         print("input dir:" + indir)
         print("paired:", pairedEnd)
         print("-" * 80)  # , "\n"
 
-        print("--- Environment ----------------------------------------------------------------")
-        print("$TMPDIR: " + os.getenv('TMPDIR', ""))
-        print("$HOSTNAME: " + os.getenv('HOSTNAME', ""))
-        print("-" * 80,)
+        print(
+            "--- Environment ----------------------------------------------------------------"
+        )
+        print("$TMPDIR: " + os.getenv("TMPDIR", ""))
+        print("$HOSTNAME: " + os.getenv("HOSTNAME", ""))
+        print(
+            "-" * 80,
+        )
 
     if toolsVersion:
         usedEnvs = [CONDA_SHARED_ENV, CONDA_RNASEQ_ENV]
@@ -133,28 +163,40 @@ onstart:
     if sampleSheet:
         cf.copySampleSheet(sampleSheet, outdir)
 
+
 ### main rule ##################################################################
 ################################################################################
 if not fromBAM:
+
     rule all:
         input:
-            expand("originalFASTQ/{sample}{read}.fastq.gz", sample=samples, read=reads if pairedEnd else [reads[0]]),
+            expand(
+                "originalFASTQ/{sample}{read}.fastq.gz",
+                sample=samples,
+                read=reads if pairedEnd else [reads[0]],
+            ),
             run_FastQC(fastqc),
-            run_Trimming(trim, fastqc = False),
+            run_Trimming(trim, fastqc=False),
             run_deepTools_qc(),
-            "multiQC/multiqc_report.html"
+            "multiQC/multiqc_report.html",
 
 else:
+
     rule all:
         input:
             run_deepTools_qc(),
-            run_deseq2()
+            run_deseq2(),
+
 
 ### execute after  finished ####################################################
 ################################################################################
 onsuccess:
     if "verbose" in config and config["verbose"]:
-        print("\n--- smRNA-seq workflow finished successfully! ------------------------------------\n")
+        print(
+            "\n--- smRNA-seq workflow finished successfully! ------------------------------------\n"
+        )
+
+
 
 onerror:
     print("\n !!! ERROR in smRNA-seq workflow! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")


### PR DESCRIPTION
## Summary
- **miRBase URL**: PR #1178's codespell autofix mangled `snakePipes/shared/tools/smallrna/common.py` — `https://www.mirbase.org/download/hsa.gff3` (`hsa` = miRBase's species code for human) became `.../has.gff3`, which 404s. Reverted it and added `hsa` to `.codespell-ignore.txt`. Audited the rest of #1178's diff for other URL damage: this was the only instance.
- **zizmor** (59 findings, previously skipped): pinned every `uses:` in the 4 workflow files to a commit SHA (with a `# vX.Y.Z` comment for readability), added `persist-credentials: false` to every `actions/checkout` step, and added `permissions: contents: read` at the workflow level in each file.
- **snakefmt** (previously skipped, crashed on `preprocessing/Snakefile`): the crash traces to a snakefmt bug triggered by an `if:`/`else:` block containing `include:` statements followed later by an `onstart:` block. Restructured the `if fastqc: ... else: fastqc = False` block into two separate `if` statements (semantically identical) to route around it, confirmed with a minimal repro before applying it. `pre-commit run --all-files` then ran clean, so all 12 Snakefiles got the pending repo-wide snakefmt reformat.
- Dropped the `ci: skip:` list from `.pre-commit-config.yaml` (now empty) and the `SKIP: zizmor,snakefmt` env from the CI `lint` job — all 8 hooks run enforced everywhere now.

## Test plan
- [x] `pre-commit run --all-files` passes clean, all hooks, no skips
- [x] CI passes on this PR